### PR TITLE
added OpenCL for the ROCm platform

### DIFF
--- a/OpenCL.make
+++ b/OpenCL.make
@@ -3,22 +3,23 @@ ifndef COMPILER
 define compiler_help
 Set COMPILER to change flags (defaulting to GNU).
 Available compilers are:
-  GNU CLANG INTEL CRAY
+  GNU CLANG INTEL CRAY HCC
 
 endef
 $(info $(compiler_help))
 COMPILER=GNU
 endif
 
+COMPILER_HCC = g++
 COMPILER_GNU = g++
 COMPILER_CLANG = clang++
 COMPILER_INTEL = icpc
 COMPILER_CRAY = CC
 CXX = $(COMPILER_$(COMPILER))
 
-FLAGS_ = -O3 -std=c++11
 FLAGS_GNU = -O3 -std=c++11
 FLAGS_CLANG = -O3 -std=c++11
+FLAGS_HCC = -O3 -std=c++11 -I/opt/rocm/opencl/include/
 FLAGS_INTEL = -O3 -std=c++11
 FLAGS_CRAY = -O3 -hstd=c++11
 CXXFLAGS=$(FLAGS_$(COMPILER))


### PR DESCRIPTION
```
GPU-STREAM
Version: 3.1
Implementation: OpenCL
Running kernels 100 times
Precision: double
Array size: 268.4 MB (=0.3 GB)
Total size: 805.3 MB (=0.8 GB)
Using OpenCL device gfx803
Driver: 1.1 (HSA,LC)
Reduction kernel config: 256 groups of size 256
Function    MBytes/sec  Min (sec)   Max         Average     
Copy        409471.915  0.00131     0.00137     0.00133     
Mul         409624.689  0.00131     0.00137     0.00134     
Add         418105.745  0.00193     0.00219     0.00200     
Triad       417470.030  0.00193     0.00228     0.00199     
Dot         461460.829  0.00116     0.00126     0.00120
```
created a specific target for OpenCL on the rocm platform. The only difference to vanilla gcc are the CXXFLAGS. But consider this as a placeholder for future rocm releases when hcc can be used to link OpenCL binaries as well.