### PR TITLE
Updated the Makefile for SYCL 

### DIFF
--- a/SYCL.make
+++ b/SYCL.make
@@ -1,11 +1,11 @@
 
-COMPUTECPP_FLAGS = $(shell computecpp_info --dump-device-compiler-flags)
+COMPUTECPP_FLAGS = $(shell $(COMPUTECPP_PREFIX)/bin/computecpp_info --dump-device-compiler-flags)
 
 sycl-stream: main.cpp SYCLStream.cpp SYCLStream.sycl
-	$(CXX) -O3 -std=c++11 -DSYCL main.cpp SYCLStream.cpp -include SYCLStream.sycl $(EXTRA_FLAGS) -lComputeCpp -lOpenCL -o $@
+	$(CXX) -O3 -std=c++11 -DSYCL main.cpp SYCLStream.cpp -I$(COMPUTECPP_PREFIX)/include -include SYCLStream.sycl $(EXTRA_FLAGS) -L$(COMPUTECPP_PREFIX)/lib -lComputeCpp -lOpenCL -Wl,--rpath=$(COMPUTECPP_PREFIX)/lib/ -o $@
 
 SYCLStream.sycl: SYCLStream.cpp
-	compute++ SYCLStream.cpp $(COMPUTECPP_FLAGS) -c
+	$(COMPUTECPP_PREFIX)/bin/compute++ SYCLStream.cpp $(COMPUTECPP_FLAGS) -c -I$(COMPUTECPP_PREFIX)/include -o $@
 
 .PHONY: clean
 clean:

--- a/SYCL.make
+++ b/SYCL.make
@@ -1,11 +1,11 @@
 
-COMPUTECPP_FLAGS = $(shell $(COMPUTECPP_PREFIX)/bin/computecpp_info --dump-device-compiler-flags)
+COMPUTECPP_FLAGS = $(shell $(COMPUTECPP_PACKAGE_ROOT_DIR)/bin/computecpp_info --dump-device-compiler-flags)
 
 sycl-stream: main.cpp SYCLStream.cpp SYCLStream.sycl
-	$(CXX) -O3 -std=c++11 -DSYCL main.cpp SYCLStream.cpp -I$(COMPUTECPP_PREFIX)/include -include SYCLStream.sycl $(EXTRA_FLAGS) -L$(COMPUTECPP_PREFIX)/lib -lComputeCpp -lOpenCL -Wl,--rpath=$(COMPUTECPP_PREFIX)/lib/ -o $@
+	$(CXX) -O3 -std=c++11 -DSYCL main.cpp SYCLStream.cpp -I$(COMPUTECPP_PACKAGE_ROOT_DIR)/include -include SYCLStream.sycl $(EXTRA_FLAGS) -L$(COMPUTECPP_PACKAGE_ROOT_DIR)/lib -lComputeCpp -lOpenCL -Wl,--rpath=$(COMPUTECPP_PACKAGE_ROOT_DIR)/lib/ -o $@
 
 SYCLStream.sycl: SYCLStream.cpp
-	$(COMPUTECPP_PREFIX)/bin/compute++ SYCLStream.cpp $(COMPUTECPP_FLAGS) -c -I$(COMPUTECPP_PREFIX)/include -o $@
+	$(COMPUTECPP_PACKAGE_ROOT_DIR)/bin/compute++ SYCLStream.cpp $(COMPUTECPP_FLAGS) -c -I$(COMPUTECPP_PACKAGE_ROOT_DIR)/include -o $@
 
 .PHONY: clean
 clean:

--- a/SYCLStream.cpp
+++ b/SYCLStream.cpp
@@ -49,9 +49,9 @@ SYCLStream<T>::SYCLStream(const unsigned int ARRAY_SIZE, const int device_index)
 
   queue = new cl::sycl::queue(dev, [&](cl::sycl::exception_list l) {
       try {
-      for(auto e: l) {
-        std::rethrow_exception(e);
-      }
+        for(auto e: l) {
+          std::rethrow_exception(e);
+        }
       } catch (cl::sycl::exception e) {
         std::cout << e.what();
       }

--- a/SYCLStream.cpp
+++ b/SYCLStream.cpp
@@ -47,14 +47,25 @@ SYCLStream<T>::SYCLStream(const unsigned int ARRAY_SIZE, const int device_index)
   std::cout << "Driver: " << getDeviceDriver(device_index) << std::endl;
   std::cout << "Reduction kernel config: " << dot_num_groups << " groups of size " << dot_wgsize << std::endl;
 
-  queue = new cl::sycl::queue(dev, [&](cl::sycl::exception_list l) {
-      try {
-        for(auto e: l) {
-          std::rethrow_exception(e);
-        }
-      } catch (cl::sycl::exception e) {
-        std::cout << e.what();
+  queue = new cl::sycl::queue(dev, [&](cl::sycl::exception_list l)
+  {
+    bool error = false;
+    for(auto e: l)
+    {
+      try
+      {
+        std::rethrow_exception(e);
       }
+      catch (cl::sycl::exception e)
+      {
+        std::cout << e.what();
+        error = true;
+      }
+    }
+    if(error)
+    {
+      throw std::runtime_error("SYCL errors detected");
+    }
   });
 
   /* Pre-build the kernels */

--- a/SYCLStream.cpp
+++ b/SYCLStream.cpp
@@ -58,20 +58,13 @@ SYCLStream<T>::SYCLStream(const unsigned int ARRAY_SIZE, const int device_index)
   });
 
   /* Pre-build the kernels */
-  cl::sycl::vector_class<cl::sycl::program> v;
-  v.push_back(cl::sycl::program{queue->get_context()});
-  v.back().compile_from_kernel_name<init_kernel>();
-  v.push_back(cl::sycl::program{queue->get_context()});
-  v.back().compile_from_kernel_name<copy_kernel>();
-  v.push_back(cl::sycl::program{queue->get_context()});
-  v.back().compile_from_kernel_name<mul_kernel>();
-  v.push_back(cl::sycl::program{queue->get_context()});
-  v.back().compile_from_kernel_name<add_kernel>();
-  v.push_back(cl::sycl::program{queue->get_context()});
-  v.back().compile_from_kernel_name<triad_kernel>();
-  v.push_back(cl::sycl::program{queue->get_context()});
-  v.back().compile_from_kernel_name<dot_kernel>();
-  p = new program(v);
+  p = new program(queue->get_context());
+  p->build_from_kernel_name<init_kernel>();
+  p->build_from_kernel_name<copy_kernel>();
+  p->build_from_kernel_name<mul_kernel>();
+  p->build_from_kernel_name<add_kernel>();
+  p->build_from_kernel_name<triad_kernel>();
+  p->build_from_kernel_name<dot_kernel>();
 
   // Create buffers
   d_a = new buffer<T>(array_size);


### PR DESCRIPTION
This pull request contains:

-  An update to SYCL.make to use a new variable, containing the path to the ComputeCpp installation. The variable is `COMPUTECPP_PACKAGE_ROOT_DIR`, matching the one used in the build for [ComputeCpp SDK](https://github.com/codeplaysoftware/computecpp-sdk).