### PR TITLE
Minor SYCL and OpenCL fixes

### DIFF
--- a/OCLStream.cpp
+++ b/OCLStream.cpp
@@ -186,6 +186,8 @@ OCLStream<T>::~OCLStream()
   delete mul_kernel;
   delete add_kernel;
   delete triad_kernel;
+
+  devices.clear();
 }
 
 template <class T>

--- a/SYCL.make
+++ b/SYCL.make
@@ -1,12 +1,18 @@
 
 COMPUTECPP_FLAGS = $(shell $(COMPUTECPP_PACKAGE_ROOT_DIR)/bin/computecpp_info --dump-device-compiler-flags)
 
-sycl-stream: main.cpp SYCLStream.cpp SYCLStream.sycl
-	$(CXX) -O3 -std=c++11 -DSYCL main.cpp SYCLStream.cpp -I$(COMPUTECPP_PACKAGE_ROOT_DIR)/include -include SYCLStream.sycl $(EXTRA_FLAGS) -L$(COMPUTECPP_PACKAGE_ROOT_DIR)/lib -lComputeCpp -lOpenCL -Wl,--rpath=$(COMPUTECPP_PACKAGE_ROOT_DIR)/lib/ -o $@
+sycl-stream: main.o SYCLStream.o SYCLStream.sycl
+	$(CXX) -O3 -std=c++11 -DSYCL main.o SYCLStream.o $(EXTRA_FLAGS) -L$(COMPUTECPP_PACKAGE_ROOT_DIR)/lib -lComputeCpp -lOpenCL -Wl,--rpath=$(COMPUTECPP_PACKAGE_ROOT_DIR)/lib/ -o $@ 
+
+main.o: main.cpp
+	$(CXX) -O3 -std=c++11 -DSYCL main.cpp -c -I$(COMPUTECPP_PACKAGE_ROOT_DIR)/include  $(EXTRA_FLAGS) -o $@ 
+
+SYCLStream.o: SYCLStream.cpp SYCLStream.sycl
+	$(CXX) -O3 -std=c++11 -DSYCL SYCLStream.cpp -c -I$(COMPUTECPP_PACKAGE_ROOT_DIR)/include -include SYCLStream.sycl $(EXTRA_FLAGS) -o $@ 
 
 SYCLStream.sycl: SYCLStream.cpp
-	$(COMPUTECPP_PACKAGE_ROOT_DIR)/bin/compute++ SYCLStream.cpp $(COMPUTECPP_FLAGS) -c -I$(COMPUTECPP_PACKAGE_ROOT_DIR)/include -o $@
+	$(COMPUTECPP_PACKAGE_ROOT_DIR)/bin/compute++ -DSYCL SYCLStream.cpp $(COMPUTECPP_FLAGS) -c -I$(COMPUTECPP_PACKAGE_ROOT_DIR)/include -o $@ 
 
 .PHONY: clean
 clean:
-	rm -f sycl-stream SYCLStream.sycl SYCLStream.bc
+	rm -f sycl-stream SYCLStream.sycl main.o SYCLStream.o

--- a/SYCLStream.cpp
+++ b/SYCLStream.cpp
@@ -94,6 +94,7 @@ SYCLStream<T>::~SYCLStream()
 
   delete p;
   delete queue;
+  devices.clear();
 }
 
 template <class T>
@@ -321,7 +322,6 @@ std::string getDeviceDriver(const int device)
 
   return driver;
 }
-
 
 // TODO: Fix kernel names to allow multiple template specializations
 template class SYCLStream<float>;


### PR DESCRIPTION
* Fix for OpenCL/SYCL behaviour with global objects
* Separated makefile for SYCL to get more concise error messages and reduce compilation time