### PR TITLE
Making BabelStream's SYCL code compliant

### DIFF
--- a/SYCLStream.cpp
+++ b/SYCLStream.cpp
@@ -185,8 +185,8 @@ T SYCLStream<T>::dot()
     cgh.parallel_for<dot_kernel>(p->get_kernel<dot_kernel>(),
       nd_range<1>(dot_num_groups*dot_wgsize, dot_wgsize), [=](nd_item<1> item)
     {
-      size_t i = item.get_global(0);
-      size_t li = item.get_local(0);
+      size_t i = item.get_global_id(0);
+      size_t li = item.get_local_id(0);
       size_t global_size = item.get_global_range()[0];
 
       wg_sum[li] = 0.0;

--- a/SYCLStream.cpp
+++ b/SYCLStream.cpp
@@ -16,6 +16,9 @@ using namespace cl::sycl;
 bool cached = false;
 std::vector<device> devices;
 void getDeviceList(void);
+#ifdef COMPUTECPP_CE
+program * p;
+#endif
 
 template <class T>
 SYCLStream<T>::SYCLStream(const unsigned int ARRAY_SIZE, const int device_index)
@@ -66,6 +69,17 @@ SYCLStream<T>::SYCLStream(const unsigned int ARRAY_SIZE, const int device_index)
       throw std::runtime_error("SYCL errors detected");
     }
   });
+  
+  #ifdef COMPUTECPP_CE
+  /* Pre-build the kernels */
+  p = new program(queue->get_context());
+  p->build_with_kernel_type<init_kernel>();
+  p->build_with_kernel_type<copy_kernel>();
+  p->build_with_kernel_type<mul_kernel>();
+  p->build_with_kernel_type<add_kernel>();
+  p->build_with_kernel_type<triad_kernel>();
+  p->build_with_kernel_type<dot_kernel>();
+  #endif
 
   // Create buffers
   d_a = new buffer<T>(array_size);
@@ -81,8 +95,9 @@ SYCLStream<T>::~SYCLStream()
   delete d_b;
   delete d_c;
   delete d_sum;
-
-
+  #ifdef COMPUTECPP_CE
+  delete p;
+  #endif
   delete queue;
   devices.clear();
 }
@@ -94,7 +109,12 @@ void SYCLStream<T>::copy()
   {
     auto ka = d_a->template get_access<access::mode::read>(cgh);
     auto kc = d_c->template get_access<access::mode::write>(cgh);
+    #ifdef COMPUTECPP_CE
+    cgh.parallel_for<copy_kernel>(p->get_kernel<copy_kernel>(),
+          range<1>{array_size}, [=](item<1> item)
+    #else
     cgh.parallel_for<copy_kernel>(range<1>{array_size}, [=](item<1> item)
+    #endif
     {
       auto id = item.get_id(0);
       kc[id] = ka[id];
@@ -111,7 +131,12 @@ void SYCLStream<T>::mul()
   {
     auto kb = d_b->template get_access<access::mode::write>(cgh);
     auto kc = d_c->template get_access<access::mode::read>(cgh);
+    #ifdef COMPUTECPP_CE
+    cgh.parallel_for<mul_kernel>(p->get_kernel<mul_kernel>(),
+      range<1>{array_size}, [=](item<1> item)
+    #else
     cgh.parallel_for<mul_kernel>(range<1>{array_size}, [=](item<1> item)
+    #endif
     {
       auto id = item.get_id(0);
       kb[id] = scalar * kc[id];
@@ -128,7 +153,12 @@ void SYCLStream<T>::add()
     auto ka = d_a->template get_access<access::mode::read>(cgh);
     auto kb = d_b->template get_access<access::mode::read>(cgh);
     auto kc = d_c->template get_access<access::mode::write>(cgh);
+    #ifdef COMPUTECPP_CE
+    cgh.parallel_for<add_kernel>(p->get_kernel<add_kernel>(),
+      range<1>{array_size}, [=](item<1> item)
+    #else
     cgh.parallel_for<add_kernel>(range<1>{array_size}, [=](item<1> item)
+    #endif
     {
       auto id = item.get_id(0);
       kc[id] = ka[id] + kb[id];
@@ -146,7 +176,12 @@ void SYCLStream<T>::triad()
     auto ka = d_a->template get_access<access::mode::write>(cgh);
     auto kb = d_b->template get_access<access::mode::read>(cgh);
     auto kc = d_c->template get_access<access::mode::read>(cgh);
+    #ifdef COMPUTECPP_CE
+    cgh.parallel_for<triad_kernel>(p->get_kernel<triad_kernel>(),
+      range<1>{array_size}, [=](item<1> item)
+    #else
     cgh.parallel_for<triad_kernel>(range<1>{array_size}, [=](item<1> item)
+    #endif
     {
       auto id = item.get_id(0);
       ka[id] = kb[id] + scalar * kc[id];
@@ -167,8 +202,12 @@ T SYCLStream<T>::dot()
     auto wg_sum = accessor<T, 1, access::mode::read_write, access::target::local>(range<1>(dot_wgsize), cgh);
 
     size_t N = array_size;
-
+    #ifdef COMPUTECPP_CE
+    cgh.parallel_for<dot_kernel>(p->get_kernel<dot_kernel>(),
+      nd_range<1>(dot_num_groups*dot_wgsize, dot_wgsize), [=](nd_item<1> item)
+    #else
     cgh.parallel_for<dot_kernel>(nd_range<1>(dot_num_groups*dot_wgsize, dot_wgsize), [=](nd_item<1> item)
+    #endif
     {
       size_t i = item.get_global_id(0);
       size_t li = item.get_local_id(0);
@@ -209,7 +248,12 @@ void SYCLStream<T>::init_arrays(T initA, T initB, T initC)
     auto ka = d_a->template get_access<access::mode::write>(cgh);
     auto kb = d_b->template get_access<access::mode::write>(cgh);
     auto kc = d_c->template get_access<access::mode::write>(cgh);
+    #ifdef COMPUTECPP_CE
+    cgh.parallel_for<init_kernel>(p->get_kernel<init_kernel>(),
+      range<1>{array_size}, [=](item<1> item)
+    #else
     cgh.parallel_for<init_kernel>(range<1>{array_size}, [=](item<1> item)
+    #endif
     {
       auto id = item.get_id(0);
       ka[id] = initA;

--- a/SYCLStream.h
+++ b/SYCLStream.h
@@ -15,6 +15,9 @@
 
 #define IMPLEMENTATION_STRING "SYCL"
 
+// allows a use of 'parallel_for' currently known to be supported by ComputeCpp
+#define COMPUTECPP_CE
+
 namespace sycl_kernels
 {
   template <class T> class init;

--- a/SYCLStream.h
+++ b/SYCLStream.h
@@ -15,9 +15,6 @@
 
 #define IMPLEMENTATION_STRING "SYCL"
 
-// allows a use of 'parallel_for' currently known to be supported by ComputeCpp
-#define COMPUTECPP_CE
-
 namespace sycl_kernels
 {
   template <class T> class init;


### PR DESCRIPTION
**1. Deprecated code**

```
'get_global' is deprecated: SYCL 1.2.1
revision 3 replaces nd_item::get_global with nd_item::get_global_id.
```

```
'get_local' is deprecated: SYCL 1.2.1 revision 3 replaces
nd_item::get_local with nd_item::get_local_id.
```
 

**2. Non-official code**

Before closing this with saying "ComputeCpp claims it fully conformant with SYCL 1.2.1", please note that while this is correct, the notion of using the pre-built kernel in with `parallel_for` is _not currently_ part of the SYCL Specification - v1.2.1 Revision 5.

**The issue:**
The SYCL specification does not include an overload of `handler::parallel_for` that accepts syclKernel built from a program. For example, `parallel_for(syclKernel, nd_range, functor)` is not conformant with specification at the moment. The reason because of which this **works with ComputeCpp** for quite some time now, is that this functionality _has probably been_ a part of past version of the specification.

**Suggestion:**
Thus, I suggest disabling/removing the use of this feature from BabelStream just in case it needs to be fully SYCL compliant and independent to a specific SYCL implementation (i.e., triSYCL doesn't support it). **Eventually**, when/if the feature gets added officially to the specification, it can be re-introduced in the code.

---

**Reference:**
All function overloads for `parallel_for` can be seen in the latest revision of the official SYCL spec:
https://www.khronos.org/registry/SYCL/specs/sycl-1.2.1.pdf#page=167