### PR TITLE
Add GNU OpenACC support for AMD GCN

### DIFF
--- a/ACCStream.cpp
+++ b/ACCStream.cpp
@@ -10,8 +10,8 @@
 template <class T>
 ACCStream<T>::ACCStream(const unsigned int ARRAY_SIZE, T *a, T *b, T *c, int device)
 {
-
-  acc_set_device_num(device, acc_device_nvidia);
+  acc_device_t device_type = acc_get_device_type();
+  acc_set_device_num(device, device_type);
 
   array_size = ARRAY_SIZE;
 
@@ -139,7 +139,8 @@ T ACCStream<T>::dot()
 void listDevices(void)
 {
   // Get number of devices
-  int count = acc_get_num_devices(acc_device_nvidia);
+  acc_device_t device_type = acc_get_device_type();
+  int count = acc_get_num_devices(device_type);
 
   // Print device list
   if (count == 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Compiler options for OpenMP GNU offloading to NVIDIA and AMD.
+- Compiler options for OpenMP and OpenACC GNU offloading to NVIDIA and AMD.
 
 ### Changed
 - Use cl::sycl::id parameters instead of cl::sycl::item.

--- a/OpenACC.make
+++ b/OpenACC.make
@@ -3,7 +3,7 @@ ifndef COMPILER
 define compiler_help
 Set COMPILER to ensure correct flags are set.
 Available compilers are:
-  PGI CRAY
+  PGI CRAY GNU
 endef
 $(info $(compiler_help))
 endif
@@ -11,6 +11,7 @@ endif
 COMPILER_ = $(CXX)
 COMPILER_PGI = pgc++
 COMPILER_CRAY = CC
+COMPILER_GNU = g++
 
 FLAGS_ = -O3 -std=c++11
 
@@ -48,6 +49,7 @@ FLAGS_PGI += $(TARGET_FLAGS_$(TARGET))
 endif
 
 FLAGS_CRAY = -hstd=c++11
+FLAGS_GNU = -O3 -std=c++11 -Drestrict=__restrict -fopenacc
 CXXFLAGS = $(FLAGS_$(COMPILER))
 
 acc-stream: main.cpp ACCStream.cpp


### PR DESCRIPTION
This adds GNU OpenACC support, similar to that recently added for OpenMP. There's also a few code changes needed to support GNU C++ and AMD devices.

* Autodetect the device type, rather than hard-code NVidia.
* Add GNU command line options to the makefile, and adjust the "restrict"
extension usage. For now, we assume the toolchain is only configured for one
accelerator.