### PR TITLE
Update Kokkos to support version 3+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ hip-stream
 *.sycl
 *.tar
 *.gz
+*.a
+
+KokkosCore_config.*
 
 .DS_Store
 

--- a/Kokkos.make
+++ b/Kokkos.make
@@ -1,7 +1,36 @@
 
 default: kokkos-stream
 
-include $(KOKKOS_PATH)/Makefile.kokkos
+ifndef DEVICE
+define device_help
+Set DEVICE to change flags (defaulting to OpenMP).
+Available devices are:
+  OpenMP, Serial, Pthreads, Cuda
+
+endef
+$(info $(device_help))
+DEVICE="OpenMP"
+endif
+KOKKOS_DEVICES="$(DEVICE)"
+
+ifndef ARCH
+define arch_help
+Set ARCH to change flags (defaulting to empty).
+Available architectures are:
+  AMDAVX
+  ARMv80 ARMv81 ARMv8-ThunderX
+  BGQ Power7 Power8 Power9
+  WSM SNB HSW BDW SKX KNC KNL 
+  Kepler30 Kepler32 Kepler35 Kepler37 
+  Maxwell50 Maxwell52 Maxwell53 
+  Pascal60 Pascal61 
+  Volta70 Volta72
+
+endef
+$(info $(arch_help))
+ARCH=""
+endif
+KOKKOS_ARCH="$(ARCH)"
 
 ifndef COMPILER
 define compiler_help
@@ -34,14 +63,19 @@ CXX = $(NVCC_WRAPPER)
 endif
 
 OBJ = main.o KokkosStream.o
+CXXFLAGS = -O3 
+LINKFLAGS = # empty for now
 
-kokkos-stream: $(OBJ) $(KOKKOS_CPP_DEPENDS)
-	$(CXX) $(KOKKOS_LDFLAGS) -DKOKKOS -O3 $(EXTRA_FLAGS) $(OBJ) $(KOKKOS_LIBS) -o $@
 
-%.o: %.cpp
-	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) -DKOKKOS -O3 $(EXTRA_FLAGS) -c $<
+include $(KOKKOS_PATH)/Makefile.kokkos
+
+kokkos-stream: $(OBJ) $(KOKKOS_LINK_DEPENDS)
+	$(CXX) $(KOKKOS_LDFLAGS) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(KOKKOS_LIBS) $(LIB) -DKOKKOS -o $@
+
+%.o: %.cpp $(KOKKOS_CPP_DEPENDS)
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -DKOKKOS -c $<
 
 .PHONY: clean
 clean:
-	rm -f kokkos-stream main.o KokkosStream.o
+	rm -f kokkos-stream main.o KokkosStream.o Kokkos_*.o
 

--- a/README.md
+++ b/README.md
@@ -61,14 +61,17 @@ The binaries are named in the form `<model>-stream`.
 Building Kokkos
 ---------------
 
-We use the following command to build Kokkos using the Intel Compiler, specifying the `arch` appropriately, e.g. `KNL`.
+Kokkos version >= 3 requires setting the `KOKKOS_PATH` flag to the *source* directory of a distribution. 
+For example:
+
 ```
-../generate_makefile.bash --prefix=<prefix> --with-openmp --with-pthread --arch=<arch> --compiler=icpc --cxxflags=-DKOKKOS_MEMORY_ALIGNMENT=2097152
+cd 
+wget https://github.com/kokkos/kokkos/archive/3.1.01.tar.gz
+tar -xvf 3.1.01.tar.gz # should end up with ~/kokkos-3.1.01
+cd BabelStream
+make -f Kokkos.make KOKKOS_PATH=~/kokkos-3.1.01 
 ```
-For building with CUDA support, we use the following command, specifying the `arch` appropriately, e.g. `Kepler35`.
-```
-../generate_makefile.bash --prefix=<prefix> --with-cuda --with-openmp --with-pthread --arch=<arch> --with-cuda-options=enable_lambda --compiler=<path_to_kokkos_src>/bin/nvcc_wrapper
-```
+See make output for more information on supported flags.
 
 Building RAJA
 -------------


### PR DESCRIPTION
In light of https://github.com/kokkos/kokkos/issues/3178, this PR adds support for the new Kokkos 3+ style Makefile where Kokkos is compiled together with the client code.
This breaks compatibility with Kokkos 2.x.