### PR TITLE
Added support for Cray, PGI, and Armclang for Kokkos and OpenMP

### DIFF
--- a/Kokkos.make
+++ b/Kokkos.make
@@ -36,15 +36,18 @@ ifndef COMPILER
 define compiler_help
 Set COMPILER to change flags (defaulting to GNU).
 Available compilers are:
-  GNU INTEL
+  GNU INTEL CRAY PGI ARMCLANG
 
 endef
 $(info $(compiler_help))
 COMPILER=GNU
 endif
 
+COMPILER_ARMCLANG = armclang++
 COMPILER_GNU = g++
 COMPILER_INTEL = icpc -qopt-streaming-stores=always
+COMPILER_CRAY = CC
+COMPILER_PGI = pgc++
 CXX = $(COMPILER_$(COMPILER))
 
 ifndef TARGET
@@ -66,6 +69,14 @@ OBJ = main.o KokkosStream.o
 CXXFLAGS = -O3 
 LINKFLAGS = # empty for now
 
+
+
+ifeq ($(COMPILER), GNU)
+ifeq ($(DEVICE), OpenMP)
+CXXFLAGS += -fopenmp
+LINKFLAGS += -fopenmp
+endif 
+endif
 
 include $(KOKKOS_PATH)/Makefile.kokkos
 

--- a/OpenMP.make
+++ b/OpenMP.make
@@ -41,6 +41,7 @@ FLAGS_NEC = -O4 -finline -std=c++11
 CXXFLAGS = $(FLAGS_$(COMPILER))
 
 # OpenMP flags for CPUs
+OMP_ARMCLANG_CPU   = -fopenmp
 OMP_GNU_CPU   = -fopenmp
 OMP_INTEL_CPU = -qopenmp
 OMP_CRAY_CPU  = -fopenmp

--- a/OpenMP.make
+++ b/OpenMP.make
@@ -3,7 +3,7 @@ ifndef COMPILER
 define compiler_help
 Set COMPILER to change flags (defaulting to GNU).
 Available compilers are:
-  CLANG CRAY GNU INTEL XL PGI NEC
+  CLANG CRAY GNU INTEL XL PGI NEC ARMCLANG
 
 endef
 $(info $(compiler_help))
@@ -21,6 +21,7 @@ $(info $(target_help))
 TARGET=CPU
 endif
 
+COMPILER_ARMCLANG = armclang++
 COMPILER_GNU = g++
 COMPILER_INTEL = icpc
 COMPILER_CRAY = CC


### PR DESCRIPTION
Includes a minor bug fix for GCC where the `-fopenmp`  flag was not included.