### PR TITLE
Ensure OpenCL destructors are called in the "correct" order.

### DIFF
--- a/OCLStream.h
+++ b/OCLStream.h
@@ -31,16 +31,16 @@ class OCLStream : public Stream<T>
     // Host array for partial sums for dot kernel
     std::vector<T> sums;
 
+    // OpenCL objects
+    cl::Device device;
+    cl::Context context;
+    cl::CommandQueue queue;
+
     // Device side pointers to arrays
     cl::Buffer d_a;
     cl::Buffer d_b;
     cl::Buffer d_c;
     cl::Buffer d_sum;
-
-    // OpenCL objects
-    cl::Device device;
-    cl::Context context;
-    cl::CommandQueue queue;
 
     cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer, T, T, T> *init_kernel;
     cl::KernelFunctor<cl::Buffer, cl::Buffer> *copy_kernel;


### PR DESCRIPTION
This patch changes the OpenCL resource destructor call order.

This was the observed behavior before the patch:
```
22:43:37.600794636 - lttng_ust_opencl:clReleaseContext_entry: context: 0xa193b0
22:43:37.600795360 - lttng_ust_opencl:clReleaseContext_exit: errcode_ret_val: CL_SUCCESS
22:43:37.600795553 - lttng_ust_opencl:clReleaseDevice_entry: device: 0x915b20
22:43:37.600795746 - lttng_ust_opencl:clReleaseDevice_exit: errcode_ret_val: CL_SUCCESS
22:43:37.600796192 - lttng_ust_opencl:clReleaseMemObject_entry: memobj: 0xa110d0
22:43:37.600811810 - lttng_ust_opencl:clReleaseMemObject_exit: errcode_ret_val: CL_SUCCESS
22:43:37.600812203 - lttng_ust_opencl:clReleaseMemObject_entry: memobj: 0x9dfe20
22:43:37.603779984 - lttng_ust_opencl:clReleaseMemObject_exit: errcode_ret_val: CL_SUCCESS
22:43:37.603780426 - lttng_ust_opencl:clReleaseMemObject_entry: memobj: 0xe86ef0
22:43:37.605993857 - lttng_ust_opencl:clReleaseMemObject_exit: errcode_ret_val: CL_SUCCESS
22:43:37.605994236 - lttng_ust_opencl:clReleaseMemObject_entry: memobj: 0x13e2020
22:43:37.606461625 - lttng_ust_opencl:clReleaseMemObject_exit: errcode_ret_val: CL_SUCCESS
```

This is the new behavior:

```
22:55:04.539915076 - lttng_ust_opencl:clReleaseMemObject_entry: memobj: 0xeacc80
22:55:04.539946798 - lttng_ust_opencl:clReleaseMemObject_exit: errcode_ret_val: CL_SUCCESS
22:55:04.539947099 - lttng_ust_opencl:clReleaseMemObject_entry: memobj: 0xeda0d0
22:55:04.542216921 - lttng_ust_opencl:clReleaseMemObject_exit: errcode_ret_val: CL_SUCCESS
22:55:04.542217570 - lttng_ust_opencl:clReleaseMemObject_entry: memobj: 0x134fef0
22:55:04.544466259 - lttng_ust_opencl:clReleaseMemObject_exit: errcode_ret_val: CL_SUCCESS
22:55:04.544466760 - lttng_ust_opencl:clReleaseMemObject_entry: memobj: 0x18ab020
22:55:04.544929270 - lttng_ust_opencl:clReleaseMemObject_exit: errcode_ret_val: CL_SUCCESS
22:55:04.544929998 - lttng_ust_opencl:clReleaseCommandQueue_entry: command_queue: 0x133d9b0
22:55:04.544932884 - lttng_ust_opencl:clReleaseCommandQueue_exit: errcode_ret_val: CL_SUCCESS
22:55:04.544934886 - lttng_ust_opencl:clReleaseContext_entry: context: 0xee23b0
22:55:04.544935608 - lttng_ust_opencl:clReleaseContext_exit: errcode_ret_val: CL_SUCCESS
22:55:04.544935964 - lttng_ust_opencl:clReleaseDevice_entry: device: 0xddeb20
22:55:04.544936437 - lttng_ust_opencl:clReleaseDevice_exit: errcode_ret_val: CL_SUCCESS
```
The old behavior is correct but could lead to hanging on some buggy platform.