### PR TITLE
Add PRK Nstream kernel

### DIFF
--- a/ACCStream.cpp
+++ b/ACCStream.cpp
@@ -121,6 +121,22 @@ void ACCStream<T>::triad()
 }
 
 template <class T>
+void ACCStream<T>::nstream()
+{
+  const T scalar = startScalar;
+
+  int array_size = this->array_size;
+  T * restrict a = this->a;
+  T * restrict b = this->b;
+  T * restrict c = this->c;
+  #pragma acc parallel loop present(a[0:array_size],  b[0:array_size], c[0:array_size]) wait
+  for (int i = 0; i < array_size; i++)
+  {
+    a[i] += b[i] + scalar * c[i];
+  }
+}
+
+template <class T>
 T ACCStream<T>::dot()
 {
   T sum = 0.0;

--- a/ACCStream.h
+++ b/ACCStream.h
@@ -35,6 +35,7 @@ class ACCStream : public Stream<T>
     virtual void add() override;
     virtual void mul() override;
     virtual void triad() override;
+    virtual void nstream() override;
     virtual T dot() override;
 
     virtual void init_arrays(T initA, T initB, T initC) override;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Kokkos 3 build system (No code changes made).
 - SYCL build rules for ComputeCpp, DPCPP and HipSYCL.
 - Support for CUDA Managed Memory and Page Fault memory.
+- Added nstream kernel from PRK.
 
 ### Changed
 - Default branch renamed from `master` to `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Reorder OpenCL objects in class so destructors are called in safe order.
 - Ensure all OpenCL kernels are present in destructor.
 - Normalise sum result by expected value to help false negative errors.
+- Update starting values to support new kernel in all models on all devices.
 
 ### Removed
 - Pre-building of kernels in SYCL version to ensure compatibility with SYCL 1.2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Clang compiler OpenMP flags corrected for NVIDIA target.
 - Reorder OpenCL objects in class so destructors are called in safe order.
 - Ensure all OpenCL kernels are present in destructor.
+- Normalise sum result by expected value to help false negative errors.
 
 ### Removed
 - Pre-building of kernels in SYCL version to ensure compatibility with SYCL 1.2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Cray compiler OpenMP flags updated.
 - Clang compiler OpenMP flags corrected for NVIDIA target.
 - Reorder OpenCL objects in class so destructors are called in safe order.
+- Initial values updated to support additional kernel.
 
 ### Removed
 - Pre-building of kernels in SYCL version to ensure compatibility with SYCL 1.2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ All notable changes to this project will be documented in this file.
 - Reorder OpenCL objects in class so destructors are called in safe order.
 - Ensure all OpenCL kernels are present in destructor.
 - Normalise sum result by expected value to help false negative errors.
-- Update starting values to support new kernel in all models on all devices.
 
 ### Removed
 - Pre-building of kernels in SYCL version to ensure compatibility with SYCL 1.2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ All notable changes to this project will be documented in this file.
 - Clang compiler OpenMP flags corrected for NVIDIA target.
 - Reorder OpenCL objects in class so destructors are called in safe order.
 - Ensure all OpenCL kernels are present in destructor.
-- Initial values updated to support additional kernel.
 
 ### Removed
 - Pre-building of kernels in SYCL version to ensure compatibility with SYCL 1.2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - Kokkos 3 build system (No code changes made).
 - SYCL build rules for ComputeCpp, DPCPP and HipSYCL.
 - Support for CUDA Managed Memory and Page Fault memory.
-- Added nstream kernel from PRK.
+- Added nstream kernel from PRK with associate command line option.
 
 ### Changed
 - Default branch renamed from `master` to `main`.

--- a/CUDAStream.cu
+++ b/CUDAStream.cu
@@ -212,6 +212,23 @@ void CUDAStream<T>::triad()
   check_error();
 }
 
+template <typename T>
+__global__ void nstream_kernel(T * a, const T * b, const T * c)
+{
+  const T scalar = startScalar;
+  const int i = blockDim.x * blockIdx.x + threadIdx.x;
+  a[i] += b[i] + scalar * c[i];
+}
+
+template <class T>
+void CUDAStream<T>::nstream()
+{
+  nstream_kernel<<<array_size/TBSIZE, TBSIZE>>>(d_a, d_b, d_c);
+  check_error();
+  cudaDeviceSynchronize();
+  check_error();
+}
+
 template <class T>
 __global__ void dot_kernel(const T * a, const T * b, T * sum, int array_size)
 {

--- a/CUDAStream.h
+++ b/CUDAStream.h
@@ -50,6 +50,7 @@ class CUDAStream : public Stream<T>
     virtual void add() override;
     virtual void mul() override;
     virtual void triad() override;
+    virtual void nstream() override;
     virtual T dot() override;
 
     virtual void init_arrays(T initA, T initB, T initC) override;

--- a/HIPStream.cpp
+++ b/HIPStream.cpp
@@ -182,6 +182,23 @@ void HIPStream<T>::triad()
   check_error();
 }
 
+template <typename T>
+__global__ void nstream_kernel(T * a, const T * b, const T * c)
+{
+  const T scalar = startScalar;
+  const int i = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
+  a[i] += b[i] + scalar * c[i];
+}
+
+template <class T>
+void HIPStream<T>::nstream()
+{
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(nstream_kernel<T>), dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0, d_a, d_b, d_c);
+  check_error();
+  hipDeviceSynchronize();
+  check_error();
+}
+
 template <class T>
 __global__ void dot_kernel(const T * a, const T * b, T * sum, int array_size)
 {

--- a/HIPStream.h
+++ b/HIPStream.h
@@ -41,6 +41,7 @@ class HIPStream : public Stream<T>
     virtual void add() override;
     virtual void mul() override;
     virtual void triad() override;
+    virtual void nstream() override;
     virtual T dot() override;
 
     virtual void init_arrays(T initA, T initB, T initC) override;

--- a/KokkosStream.cpp
+++ b/KokkosStream.cpp
@@ -120,6 +120,21 @@ void KokkosStream<T>::triad()
 }
 
 template <class T>
+void KokkosStream<T>::nstream()
+{
+  Kokkos::View<T*> a(*d_a);
+  Kokkos::View<T*> b(*d_b);
+  Kokkos::View<T*> c(*d_c);
+
+  const T scalar = startScalar;
+  Kokkos::parallel_for(array_size, KOKKOS_LAMBDA (const long index)
+  {
+    a[index] += b[index] + scalar*c[index];
+  });
+  Kokkos::fence();
+}
+
+template <class T>
 T KokkosStream<T>::dot()
 {
   Kokkos::View<T*> a(*d_a);

--- a/KokkosStream.hpp
+++ b/KokkosStream.hpp
@@ -41,6 +41,7 @@ class KokkosStream : public Stream<T>
     virtual void add() override;
     virtual void mul() override;
     virtual void triad() override;
+    virtual void nstream() override;
     virtual T dot() override;
 
     virtual void init_arrays(T initA, T initB, T initC) override;

--- a/OCLStream.h
+++ b/OCLStream.h
@@ -47,6 +47,7 @@ class OCLStream : public Stream<T>
     cl::KernelFunctor<cl::Buffer, cl::Buffer> * mul_kernel;
     cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer> *add_kernel;
     cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer> *triad_kernel;
+    cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer> *nstream_kernel;
     cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer, cl::LocalSpaceArg, cl_int> *dot_kernel;
 
     // NDRange configuration for the dot kernel
@@ -62,6 +63,7 @@ class OCLStream : public Stream<T>
     virtual void add() override;
     virtual void mul() override;
     virtual void triad() override;
+    virtual void nstream() override;
     virtual T dot() override;
 
     virtual void init_arrays(T initA, T initB, T initC) override;

--- a/OMPStream.h
+++ b/OMPStream.h
@@ -36,6 +36,7 @@ class OMPStream : public Stream<T>
     virtual void add() override;
     virtual void mul() override;
     virtual void triad() override;
+    virtual void nstream() override;
     virtual T dot() override;
 
     virtual void init_arrays(T initA, T initB, T initC) override;

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ But this information is not typically available in real HPC codes today, where t
 
 BabelStream therefore provides a measure of what memory bandwidth performance can be attained (by a particular programming model) if you follow today's best parallel programming best practice.
 
+BabelStream also includes the nstream kernel from the Parallel Research Kernels (PRK) project, available on [GitHub](https://github.com/ParRes/Kernels).
+Details about PRK can be found in the following references:
+
+> Van der Wijngaart, Rob F., and Timothy G. Mattson. The parallel research kernels. IEEE High Performance Extreme Computing Conference (HPEC). IEEE, 2014.
+
+> R. F. Van der Wijngaart, A. Kayi, J. R. Hammond, G. Jost, T. St. John, S. Sridharan, T. G. Mattson, J. Abercrombie, and J. Nelson. Comparing runtime systems with exascale ambitions using the Parallel Research Kernels. ISC 2016, [DOI: 10.1007/978-3-319-41321-1_17](https://doi.org/10.1007/978-3-319-41321-1_17).
+
+> Jeff R. Hammond and Timothy G. Mattson. Evaluating data parallelism in C++ using the Parallel Research Kernels. IWOCL 2019, [DOI: 10.1145/3318170.3318192](https://doi.org/10.1145/3318170.3318192).
+
 
 Website
 -------

--- a/STD20Stream.cpp
+++ b/STD20Stream.cpp
@@ -95,6 +95,20 @@ void STD20Stream<T>::triad()
 }
 
 template <class T>
+void STD20Stream<T>::nstream()
+{
+  const T scalar = startScalar;
+
+  std::for_each_n(
+    std::execution::par_unseq,
+    std::views::iota(0).begin(), array_size,
+    [&] (int i) {
+      a[i] += b[i] + scalar * c[i];
+    }
+  );
+}
+
+template <class T>
 T STD20Stream<T>::dot()
 {
   // sum += a[i] * b[i];

--- a/STD20Stream.hpp
+++ b/STD20Stream.hpp
@@ -33,6 +33,7 @@ class STD20Stream : public Stream<T>
     virtual void add() override;
     virtual void mul() override;
     virtual void triad() override;
+    virtual void nstream() override;
     virtual T dot() override;
 
     virtual void init_arrays(T initA, T initB, T initC) override;

--- a/STDStream.cpp
+++ b/STDStream.cpp
@@ -73,6 +73,17 @@ void STDStream<T>::triad()
 }
 
 template <class T>
+void STDStream<T>::nstream()
+{
+  //  a[i] += b[i] + scalar * c[i];
+  //  Need to do in two stages with C++11 STL.
+  //  1: a[i] += b[i]
+  //  2: a[i] += scalar * c[i];
+  std::transform(exe_policy, a, a+array_size, b, a, [](T ai, T bi){ return ai + bi; });
+  std::transform(exe_policy, a, a+array_size, c, a, [](T ai, T ci){ return ai + startScalar*ci; });
+}
+
+template <class T>
 T STDStream<T>::dot()
 {
   // sum = 0; sum += a[i]*b[i]; return sum;

--- a/STDStream.h
+++ b/STDStream.h
@@ -31,6 +31,7 @@ class STDStream : public Stream<T>
     virtual void add() override;
     virtual void mul() override;
     virtual void triad() override;
+    virtual void nstream() override;
     virtual T dot() override;
 
     virtual void init_arrays(T initA, T initB, T initC) override;

--- a/SYCLStream.cpp
+++ b/SYCLStream.cpp
@@ -149,6 +149,23 @@ void SYCLStream<T>::triad()
 }
 
 template <class T>
+void SYCLStream<T>::nstream()
+{
+  const T scalar = startScalar;
+  queue->submit([&](handler &cgh)
+  {
+    auto ka = d_a->template get_access<access::mode::read_write>(cgh);
+    auto kb = d_b->template get_access<access::mode::read>(cgh);
+    auto kc = d_c->template get_access<access::mode::read>(cgh);
+    cgh.parallel_for<nstream_kernel>(range<1>{array_size}, [=](id<1> idx)
+    {
+      ka[idx] += kb[idx] + scalar * kc[idx];
+    });
+  });
+  queue->wait();
+}
+
+template <class T>
 T SYCLStream<T>::dot()
 {
   queue->submit([&](handler &cgh)

--- a/SYCLStream.h
+++ b/SYCLStream.h
@@ -22,6 +22,7 @@ namespace sycl_kernels
   template <class T> class mul;
   template <class T> class add;
   template <class T> class triad;
+  template <class T> class nstream;
   template <class T> class dot;
 }
 
@@ -45,6 +46,7 @@ class SYCLStream : public Stream<T>
     typedef sycl_kernels::mul<T> mul_kernel;
     typedef sycl_kernels::add<T> add_kernel;
     typedef sycl_kernels::triad<T> triad_kernel;
+    typedef sycl_kernels::nstream<T> nstream_kernel;
     typedef sycl_kernels::dot<T> dot_kernel;
 
     // NDRange configuration for the dot kernel
@@ -60,6 +62,7 @@ class SYCLStream : public Stream<T>
     virtual void add() override;
     virtual void mul() override;
     virtual void triad() override;
+    virtual void nstream() override;
     virtual T    dot() override;
 
     virtual void init_arrays(T initA, T initB, T initC) override;

--- a/Stream.h
+++ b/Stream.h
@@ -11,10 +11,10 @@
 #include <string>
 
 // Array values
-#define startA (0.1)
-#define startB (0.2)
+#define startA (0.001)
+#define startB (0.02)
 #define startC (0.0)
-#define startScalar (0.4)
+#define startScalar (-0.4)
 
 template <class T>
 class Stream

--- a/Stream.h
+++ b/Stream.h
@@ -11,10 +11,10 @@
 #include <string>
 
 // Array values
-#define startA (0.001)
-#define startB (0.02)
+#define startA (0.1)
+#define startB (0.2)
 #define startC (0.0)
-#define startScalar (-0.4)
+#define startScalar (0.4)
 
 template <class T>
 class Stream

--- a/Stream.h
+++ b/Stream.h
@@ -29,6 +29,7 @@ class Stream
     virtual void mul() = 0;
     virtual void add() = 0;
     virtual void triad() = 0;
+    virtual void nstream() = 0;
     virtual T dot() = 0;
 
     // Copy memory between host and device

--- a/Stream.h
+++ b/Stream.h
@@ -11,10 +11,10 @@
 #include <string>
 
 // Array values
-#define startA (0.1)
-#define startB (0.2)
+#define startA (1.0)
+#define startB (0.02)
 #define startC (0.0)
-#define startScalar (0.4)
+#define startScalar (0.04)
 
 template <class T>
 class Stream

--- a/Stream.h
+++ b/Stream.h
@@ -11,10 +11,10 @@
 #include <string>
 
 // Array values
-#define startA (1.0)
-#define startB (0.02)
+#define startA (0.1)
+#define startB (0.2)
 #define startC (0.0)
-#define startScalar (0.04)
+#define startScalar (0.4)
 
 template <class T>
 class Stream

--- a/main.cpp
+++ b/main.cpp
@@ -186,7 +186,7 @@ void run()
   T sum;
 
   // List of times
-  std::vector<std::vector<double>> timings(6);
+  std::vector<std::vector<double>> timings(5);
 
   // Declare timers
   std::chrono::high_resolution_clock::time_point t1, t2;
@@ -218,17 +218,11 @@ void run()
     t2 = std::chrono::high_resolution_clock::now();
     timings[3].push_back(std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count());
 
-    // Execute nstream
-    t1 = std::chrono::high_resolution_clock::now();
-    stream->nstream();
-    t2 = std::chrono::high_resolution_clock::now();
-    timings[4].push_back(std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count());
-
     // Execute Dot
     t1 = std::chrono::high_resolution_clock::now();
     sum = stream->dot();
     t2 = std::chrono::high_resolution_clock::now();
-    timings[5].push_back(std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count());
+    timings[4].push_back(std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count());
 
   }
 
@@ -268,17 +262,16 @@ void run()
 
 
 
-  std::string labels[6] = {"Copy", "Mul", "Add", "Triad", "nstream", "Dot"};
-  size_t sizes[6] = {
+  std::string labels[6] = {"Copy", "Mul", "Add", "Triad", "Dot"};
+  size_t sizes[5] = {
     2 * sizeof(T) * ARRAY_SIZE,
     2 * sizeof(T) * ARRAY_SIZE,
     3 * sizeof(T) * ARRAY_SIZE,
     3 * sizeof(T) * ARRAY_SIZE,
-    4 * sizeof(T) * ARRAY_SIZE,
     2 * sizeof(T) * ARRAY_SIZE
   };
 
-  for (int i = 0; i < 6; i++)
+  for (int i = 0; i < 5; i++)
   {
     // Get min/max; ignore the first result
     auto minmax = std::minmax_element(timings[i].begin()+1, timings[i].end());
@@ -480,10 +473,6 @@ void check_solution(const unsigned int ntimes, std::vector<T>& a, std::vector<T>
       goldC = goldA + goldB;
     }
     goldA = goldB + scalar * goldC;
-    if (!triad_only)
-    {
-      goldA += goldB + scalar * goldC;
-    }
   }
 
   // Do the reduction

--- a/main.cpp
+++ b/main.cpp
@@ -496,7 +496,7 @@ void check_solution(const unsigned int ntimes, std::vector<T>& a, std::vector<T>
   errB /= b.size();
   double errC = std::accumulate(c.begin(), c.end(), 0.0, [&](double sum, const T val){ return sum + fabs(val - goldC); });
   errC /= c.size();
-  double errSum = fabs(sum - goldSum);
+  double errSum = fabs((sum - goldSum)/goldSum);
 
   double epsi = std::numeric_limits<T>::epsilon() * 100.0;
 

--- a/main.cpp
+++ b/main.cpp
@@ -186,7 +186,7 @@ void run()
   T sum;
 
   // List of times
-  std::vector<std::vector<double>> timings(5);
+  std::vector<std::vector<double>> timings(6);
 
   // Declare timers
   std::chrono::high_resolution_clock::time_point t1, t2;
@@ -218,11 +218,17 @@ void run()
     t2 = std::chrono::high_resolution_clock::now();
     timings[3].push_back(std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count());
 
+    // Execute nstream
+    t1 = std::chrono::high_resolution_clock::now();
+    stream->nstream();
+    t2 = std::chrono::high_resolution_clock::now();
+    timings[4].push_back(std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count());
+
     // Execute Dot
     t1 = std::chrono::high_resolution_clock::now();
     sum = stream->dot();
     t2 = std::chrono::high_resolution_clock::now();
-    timings[4].push_back(std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count());
+    timings[5].push_back(std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count());
 
   }
 
@@ -262,16 +268,17 @@ void run()
 
 
 
-  std::string labels[5] = {"Copy", "Mul", "Add", "Triad", "Dot"};
-  size_t sizes[5] = {
+  std::string labels[6] = {"Copy", "Mul", "Add", "Triad", "nstream", "Dot"};
+  size_t sizes[6] = {
     2 * sizeof(T) * ARRAY_SIZE,
     2 * sizeof(T) * ARRAY_SIZE,
     3 * sizeof(T) * ARRAY_SIZE,
     3 * sizeof(T) * ARRAY_SIZE,
+    4 * sizeof(T) * ARRAY_SIZE,
     2 * sizeof(T) * ARRAY_SIZE
   };
 
-  for (int i = 0; i < 5; i++)
+  for (int i = 0; i < 6; i++)
   {
     // Get min/max; ignore the first result
     auto minmax = std::minmax_element(timings[i].begin()+1, timings[i].end());
@@ -473,6 +480,10 @@ void check_solution(const unsigned int ntimes, std::vector<T>& a, std::vector<T>
       goldC = goldA + goldB;
     }
     goldA = goldB + scalar * goldC;
+    if (!triad_only)
+    {
+      goldA += goldB + scalar * goldC;
+    }
   }
 
   // Do the reduction


### PR DESCRIPTION
This PR adds a new kernel to BabelStream, the `nstream` kernel borrowed from [PRK](https://github.com/ParRes/Kernels).
The new kernel computes:
```
a[i] += b[i] + scalar * c[i];
```
This has 3 reads and 1 write which is a heaver read ratio than Triad. Non-temporal stores on CPUs are also not required as the `a` array must be first read and be placed in cache.

~To support this, the initial values of the arrays are changed to ensure the results validate.~ no longer required.

The OpenACC kernel does not seem to respect the `+=`; it does not include the initial value of `a` just overwrites it the same as Triad which is incorrect.

The modern C++ is hard to test because not all compilers support the required APIs in the Parallel STL, or else the software stack is fragile.