### PR TITLE
Include stdlib.h for aligned_alloc

### DIFF
--- a/OMPStream.cpp
+++ b/OMPStream.cpp
@@ -5,6 +5,7 @@
 // For full license terms please see the LICENSE file distributed with this
 // source code
 
+#include <cstdlib>  // For aligned_alloc
 #include "OMPStream.h"
 
 #ifndef ALIGNMENT

--- a/RAJAStream.cpp
+++ b/RAJAStream.cpp
@@ -5,6 +5,7 @@
 // For full license terms please see the LICENSE file distributed with this
 // source code
 
+#include <cstdlib>  // For aligned_alloc
 #include <stdexcept>
 #include "RAJAStream.hpp"
 


### PR DESCRIPTION
Silence "error: there are no arguments to 'aligned_alloc' that depend
on a template parameter, so a declaration of 'aligned_alloc' must be
available"

* OMPStream.cpp: #include <stdlib.h>.
* RAJAStream.cpp: Likewise.