### PR TITLE
WIP: support massive input sizes

### DIFF
--- a/src/Stream.h
+++ b/src/Stream.h
@@ -11,10 +11,10 @@
 #include <string>
 
 // Array values
-#define startA (0.1)
-#define startB (0.2)
-#define startC (0.0)
-#define startScalar (0.4)
+#define startA (0.1L)
+#define startB (0.2L)
+#define startC (0.0L)
+#define startScalar (0.4L)
 
 template <class T>
 class Stream

--- a/src/ci-prepare-bionic.sh
+++ b/src/ci-prepare-bionic.sh
@@ -133,21 +133,26 @@ setup_aocc() {
 }
 
 setup_nvhpc() {
-  echo "Preparing Nvidia HPC SDK"
-  local tarball="nvhpc.tar.gz"
-#  local url="http://localhost:8000/nvhpc_2021_219_Linux_x86_64_cuda_11.4.tar.gz"
-  local url="https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_x86_64_cuda_11.4.tar.gz"
+ echo "Preparing Nvidia HPC SDK"
+  local nvhpc_ver="22.3"
+  local nvhpc_release="2022_223"
+  local cuda_ver="11.6"
+
+  local tarball="nvhpc_$nvhpc_ver.tar.gz"
+
+  local url="https://developer.download.nvidia.com/hpc-sdk/$nvhpc_ver/nvhpc_${nvhpc_release}_Linux_x86_64_cuda_$cuda_ver.tar.gz"
   get_and_untar "$tarball" "$url"
 
-  local sdk_dir="$PWD/nvhpc_2021_219_Linux_x86_64_cuda_11.4/install_components/Linux_x86_64/21.9"
+  local sdk_dir="$PWD/nvhpc_${nvhpc_release}_Linux_x86_64_cuda_$cuda_ver/install_components/Linux_x86_64/$nvhpc_ver"
   local bin_dir="$sdk_dir/compilers/bin"
   "$bin_dir/makelocalrc" "$bin_dir" -x
 
   export_var NVHPC_SDK_DIR "$sdk_dir"
-  export_var NVHPC_CUDA_DIR "$sdk_dir/cuda/11.4"
+  export_var NVHPC_CUDA_DIR "$sdk_dir/cuda/$cuda_ver"
 
   export_var NVHPC_NVCXX "$bin_dir/nvc++"
-  export_var NVHPC_NVCC "$sdk_dir/cuda/11.4/bin/nvcc"
+  export_var NVHPC_NVCC "$bin_dir/nvcc"
+#  export_var NVHPC_NVCC "$sdk_dir/cuda/$cuda_ver/bin/nvcc"
 
   echo "Installed CUDA versions:"
   ls "$sdk_dir/cuda"

--- a/src/ci-prepare-bionic.sh
+++ b/src/ci-prepare-bionic.sh
@@ -152,6 +152,7 @@ setup_nvhpc() {
 
   export_var NVHPC_NVCXX "$bin_dir/nvc++"
   export_var NVHPC_NVCC "$bin_dir/nvcc"
+  export_var NVHPC_CUDA_VER "$cuda_ver"
 #  export_var NVHPC_NVCC "$sdk_dir/cuda/$cuda_ver/bin/nvcc"
 
   echo "Installed CUDA versions:"

--- a/src/ci-test-compile.sh
+++ b/src/ci-test-compile.sh
@@ -175,9 +175,9 @@ build_gcc() {
   local current=$("$CMAKE_BIN" --version | head -n 1 | cut -d ' ' -f3)
   local required="3.15.0"
   if [ "$(printf '%s\n' "$required" "$current" | sort -V | head -n1)" = "$required" ]; then
-    run_build $name "${GCC_CXX:?}" thrust "$cxx -DCMAKE_CUDA_COMPILER=${NVHPC_NVCC:?} -DCUDA_ARCH=$NV_ARCH -DSDK_DIR=$NVHPC_CUDA_DIR/include -DTHRUST_IMPL=CUDA -DBACKEND=CUDA"
-    run_build $name "${GCC_CXX:?}" thrust "$cxx -DCMAKE_CUDA_COMPILER=${NVHPC_NVCC:?} -DCUDA_ARCH=$NV_ARCH -DSDK_DIR=$NVHPC_CUDA_DIR/include -DTHRUST_IMPL=CUDA -DBACKEND=OMP"
-    run_build $name "${GCC_CXX:?}" thrust "$cxx -DCMAKE_CUDA_COMPILER=${NVHPC_NVCC:?} -DCUDA_ARCH=$NV_ARCH -DSDK_DIR=$NVHPC_CUDA_DIR/include -DTHRUST_IMPL=CUDA -DBACKEND=CPP"
+    run_build $name "${GCC_CXX:?}" thrust "$cxx -DCMAKE_CUDA_COMPILER=${NVHPC_NVCC:?} -DCUDA_ARCH=$NV_ARCH -DSDK_DIR=$NVHPC_CUDA_DIR/lib64/cmake -DTHRUST_IMPL=CUDA -DBACKEND=CUDA"
+    run_build $name "${GCC_CXX:?}" thrust "$cxx -DCMAKE_CUDA_COMPILER=${NVHPC_NVCC:?} -DCUDA_ARCH=$NV_ARCH -DSDK_DIR=$NVHPC_CUDA_DIR/lib64/cmake -DTHRUST_IMPL=CUDA -DBACKEND=OMP"
+    run_build $name "${GCC_CXX:?}" thrust "$cxx -DCMAKE_CUDA_COMPILER=${NVHPC_NVCC:?} -DCUDA_ARCH=$NV_ARCH -DSDK_DIR=$NVHPC_CUDA_DIR/lib64/cmake -DTHRUST_IMPL=CUDA -DBACKEND=CPP"
 
     # FIXME CUDA Thrust + TBB throws the following error:
     #    /usr/lib/gcc/x86_64-linux-gnu/9/include/avx512fintrin.h(9146): error: identifier "__builtin_ia32_rndscaless_round" is undefined
@@ -187,7 +187,7 @@ build_gcc() {
     #    /usr/lib/gcc/x86_64-linux-gnu/9/include/avx512dqintrin.h(1365): error: identifier "__builtin_ia32_fpclassss" is undefined
     #    /usr/lib/gcc/x86_64-linux-gnu/9/include/avx512dqintrin.h(1372): error: identifier "__builtin_ia32_fpclasssd" is undefined
 
-    #    run_build $name "${GCC_CXX:?}" THRUST "$cxx -DCMAKE_CUDA_COMPILER=${NVHPC_NVCC:?} -DCUDA_ARCH=$NV_ARCH -DSDK_DIR=$NVHPC_CUDA_DIR/include -DTHRUST_IMPL=CUDA -DBACKEND=TBB"
+    #    run_build $name "${GCC_CXX:?}" THRUST "$cxx -DCMAKE_CUDA_COMPILER=${NVHPC_NVCC:?} -DCUDA_ARCH=$NV_ARCH -DSDK_DIR=$NVHPC_CUDA_DIR/lib64/cmake -DTHRUST_IMPL=CUDA -DBACKEND=TBB"
   else
     echo "CMake version ${current} < ${required}, skipping Thrust models"
   fi

--- a/src/ci-test-compile.sh
+++ b/src/ci-test-compile.sh
@@ -122,7 +122,7 @@ run_build() {
 
 AMD_ARCH="gfx_903"
 NV_ARCH="sm_70"
-NV_ARCH_CCXY="cuda11.4,cc80"
+NV_ARCH_CCXY="cuda${NVHPC_CUDA_VER:?},cc80"
 
 build_gcc() {
   local name="gcc_build"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,7 +52,7 @@
 #endif
 
 // Default size of 2^25
-int ARRAY_SIZE = 33554432;
+long long ARRAY_SIZE = 33554432;
 unsigned int num_times = 100;
 unsigned int deviceIndex = 0;
 bool use_float = false;
@@ -526,7 +526,7 @@ int parseUInt(const char *str, unsigned int *output)
   return !strlen(next);
 }
 
-int parseInt(const char *str, int *output)
+int parseInt(const char *str, long long *output)
 {
   char *next;
   *output = strtol(str, &next, 10);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -458,10 +458,10 @@ template <typename T>
 void check_solution(const unsigned int ntimes, std::vector<T>& a, std::vector<T>& b, std::vector<T>& c, T& sum)
 {
   // Generate correct solution
-  T goldA = startA;
-  T goldB = startB;
-  T goldC = startC;
-  T goldSum = 0.0;
+  long double goldA = startA;
+  long double goldB = startB;
+  long double goldC = startC;
+  long double goldSum = 0.0L;
 
   const T scalar = startScalar;
 
@@ -487,13 +487,13 @@ void check_solution(const unsigned int ntimes, std::vector<T>& a, std::vector<T>
   goldSum = goldA * goldB * ARRAY_SIZE;
 
   // Calculate the average error
-  long double errA = std::accumulate(a.begin(), a.end(), 0.0, [&](double sum, const T val){ return sum + fabs(val - goldA); });
+  long double errA = std::accumulate(a.begin(), a.end(), 0.0, [&](long double sum, const T val){ return sum + fabsl(val - goldA); });
   errA /= a.size();
-  long double errB = std::accumulate(b.begin(), b.end(), 0.0, [&](double sum, const T val){ return sum + fabs(val - goldB); });
+  long double errB = std::accumulate(b.begin(), b.end(), 0.0, [&](long double sum, const T val){ return sum + fabsl(val - goldB); });
   errB /= b.size();
-  long double errC = std::accumulate(c.begin(), c.end(), 0.0, [&](double sum, const T val){ return sum + fabs(val - goldC); });
+  long double errC = std::accumulate(c.begin(), c.end(), 0.0, [&](long double sum, const T val){ return sum + fabsl(val - goldC); });
   errC /= c.size();
-  long double errSum = fabs((sum - goldSum)/goldSum);
+  long double errSum = fabsl((sum - goldSum)/goldSum);
 
   long double epsi = std::numeric_limits<T>::epsilon() * 100.0;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <cstring>
+#include <cstdint>
 
 #define VERSION_STRING "4.0"
 
@@ -52,7 +53,7 @@
 #endif
 
 // Default size of 2^25
-long long ARRAY_SIZE = 33554432;
+intptr_t ARRAY_SIZE = 33554432;
 unsigned int num_times = 100;
 unsigned int deviceIndex = 0;
 bool use_float = false;
@@ -526,7 +527,7 @@ int parseUInt(const char *str, unsigned int *output)
   return !strlen(next);
 }
 
-int parseInt(const char *str, long long *output)
+int parseInt(const char *str, intptr_t *output)
 {
   char *next;
   *output = strtol(str, &next, 10);

--- a/src/omp/OMPStream.cpp
+++ b/src/omp/OMPStream.cpp
@@ -13,7 +13,7 @@
 #endif
 
 template <class T>
-OMPStream<T>::OMPStream(const long long ARRAY_SIZE, int device)
+OMPStream<T>::OMPStream(const intptr_t ARRAY_SIZE, int device)
 {
   array_size = ARRAY_SIZE;
 
@@ -39,7 +39,7 @@ OMPStream<T>::~OMPStream()
 {
 #ifdef OMP_TARGET_GPU
   // End data region on device
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   T *c = this->c;
@@ -54,7 +54,7 @@ OMPStream<T>::~OMPStream()
 template <class T>
 void OMPStream<T>::init_arrays(T initA, T initB, T initC)
 {
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
 #ifdef OMP_TARGET_GPU
   T *a = this->a;
   T *b = this->b;
@@ -63,7 +63,7 @@ void OMPStream<T>::init_arrays(T initA, T initB, T initC)
 #else
   #pragma omp parallel for
 #endif
-  for (long long i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] = initA;
     b[i] = initB;
@@ -89,7 +89,7 @@ void OMPStream<T>::read_arrays(std::vector<T>& h_a, std::vector<T>& h_b, std::ve
 #endif
 
   #pragma omp parallel for
-  for (long long i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     h_a[i] = a[i];
     h_b[i] = b[i];
@@ -102,14 +102,14 @@ template <class T>
 void OMPStream<T>::copy()
 {
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *c = this->c;
   #pragma omp target teams distribute parallel for simd
 #else
   #pragma omp parallel for
 #endif
-  for (long long i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     c[i] = a[i];
   }
@@ -126,14 +126,14 @@ void OMPStream<T>::mul()
   const T scalar = startScalar;
 
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *b = this->b;
   T *c = this->c;
   #pragma omp target teams distribute parallel for simd
 #else
   #pragma omp parallel for
 #endif
-  for (long long i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     b[i] = scalar * c[i];
   }
@@ -148,7 +148,7 @@ template <class T>
 void OMPStream<T>::add()
 {
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   T *c = this->c;
@@ -156,7 +156,7 @@ void OMPStream<T>::add()
 #else
   #pragma omp parallel for
 #endif
-  for (long long i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     c[i] = a[i] + b[i];
   }
@@ -173,7 +173,7 @@ void OMPStream<T>::triad()
   const T scalar = startScalar;
 
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   T *c = this->c;
@@ -181,7 +181,7 @@ void OMPStream<T>::triad()
 #else
   #pragma omp parallel for
 #endif
-  for (long long i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] = b[i] + scalar * c[i];
   }
@@ -198,7 +198,7 @@ void OMPStream<T>::nstream()
   const T scalar = startScalar;
 
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   T *c = this->c;
@@ -206,7 +206,7 @@ void OMPStream<T>::nstream()
 #else
   #pragma omp parallel for
 #endif
-  for (long long i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] += b[i] + scalar * c[i];
   }
@@ -223,14 +223,14 @@ T OMPStream<T>::dot()
   T sum = 0.0;
 
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   #pragma omp target teams distribute parallel for simd map(tofrom: sum) reduction(+:sum)
 #else
   #pragma omp parallel for reduction(+:sum)
 #endif
-  for (long long i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     sum += a[i] * b[i];
   }

--- a/src/omp/OMPStream.cpp
+++ b/src/omp/OMPStream.cpp
@@ -13,7 +13,7 @@
 #endif
 
 template <class T>
-OMPStream<T>::OMPStream(const int ARRAY_SIZE, int device)
+OMPStream<T>::OMPStream(const long long ARRAY_SIZE, int device)
 {
   array_size = ARRAY_SIZE;
 
@@ -63,7 +63,7 @@ void OMPStream<T>::init_arrays(T initA, T initB, T initC)
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (long long i = 0; i < array_size; i++)
   {
     a[i] = initA;
     b[i] = initB;
@@ -89,7 +89,7 @@ void OMPStream<T>::read_arrays(std::vector<T>& h_a, std::vector<T>& h_b, std::ve
 #endif
 
   #pragma omp parallel for
-  for (int i = 0; i < array_size; i++)
+  for (long long i = 0; i < array_size; i++)
   {
     h_a[i] = a[i];
     h_b[i] = b[i];
@@ -109,7 +109,7 @@ void OMPStream<T>::copy()
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (long long i = 0; i < array_size; i++)
   {
     c[i] = a[i];
   }
@@ -133,7 +133,7 @@ void OMPStream<T>::mul()
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (long long i = 0; i < array_size; i++)
   {
     b[i] = scalar * c[i];
   }
@@ -156,7 +156,7 @@ void OMPStream<T>::add()
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (long long i = 0; i < array_size; i++)
   {
     c[i] = a[i] + b[i];
   }
@@ -181,7 +181,7 @@ void OMPStream<T>::triad()
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (long long i = 0; i < array_size; i++)
   {
     a[i] = b[i] + scalar * c[i];
   }
@@ -206,7 +206,7 @@ void OMPStream<T>::nstream()
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (long long i = 0; i < array_size; i++)
   {
     a[i] += b[i] + scalar * c[i];
   }
@@ -230,7 +230,7 @@ T OMPStream<T>::dot()
 #else
   #pragma omp parallel for reduction(+:sum)
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (long long i = 0; i < array_size; i++)
   {
     sum += a[i] * b[i];
   }

--- a/src/omp/OMPStream.h
+++ b/src/omp/OMPStream.h
@@ -21,7 +21,7 @@ class OMPStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    long long array_size;
+    intptr_t array_size;
 
     // Device side pointers
     T *a;
@@ -29,7 +29,7 @@ class OMPStream : public Stream<T>
     T *c;
 
   public:
-    OMPStream(const long long, int);
+    OMPStream(const intptr_t, int);
     ~OMPStream();
 
     virtual void copy() override;

--- a/src/omp/OMPStream.h
+++ b/src/omp/OMPStream.h
@@ -21,7 +21,7 @@ class OMPStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    int array_size;
+    long long array_size;
 
     // Device side pointers
     T *a;
@@ -29,7 +29,7 @@ class OMPStream : public Stream<T>
     T *c;
 
   public:
-    OMPStream(const int, int);
+    OMPStream(const long long, int);
     ~OMPStream();
 
     virtual void copy() override;

--- a/src/thrust/model.cmake
+++ b/src/thrust/model.cmake
@@ -53,6 +53,9 @@ macro(setup)
         message(STATUS "NVCC flags: ${CMAKE_CUDA_FLAGS} ${CMAKE_CUDA_FLAGS_${BUILD_TYPE}}")
 
 
+        # XXX NVHPC <= 21.9 has cub-config in `Linux_x86_64/21.9/cuda/11.4/include/cub/cmake`
+        # XXX NVHPC >= 22.3 has cub-config in `Linux_x86_64/22.3/cuda/11.6/lib64/cmake/cub/`
+        # same thing for thrust
         if (SDK_DIR)
             find_package(CUB REQUIRED CONFIG PATHS ${SDK_DIR}/cub)
             find_package(Thrust REQUIRED CONFIG PATHS ${SDK_DIR}/thrust)


### PR DESCRIPTION
As main memory sizes increase, we are seeing errors for very large input sizes, passed in via the command line argument `--arraysize`. This reads in an `int` which can store values up to 2,147,483,647 (`2^31 - 1`).

First, the `main.cpp` driver code is updated to parse and store the input as a `intptr_t`. This gives us a range up to all of memory.

Secondly, the OpenMP implementation is updated to:
- Store the array size as a `intptr_t` inside the class (note implementations own their own data and array size).
- Update the loop bounds of all kernels to use `intptr_t` indexing. Note we want to keep using a signed data type because it makes vectorisation easier because the [loop is countable](https://www.ibm.com/docs/en/xl-c-and-cpp-aix/11.1.0?topic=programs-countable-loops) (e.g. [MSVC](https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/vectorizer-and-parallelizer-messages?view=msvc-170#BKMK_ReasonCode100x), [Intel](https://community.intel.com/t5/Intel-C-Compiler/Vectorization-failed-because-of-unsigned-integer/td-p/1105071))

Finally, the starting literal values need the long double suffix: e.g. `0.2L`.

This PR currently updates only the OpenMP code. This change needs propagating to the other models.

## Progress

- [ ] OpenACC
- [ ] CUDA
- [ ] HIP
- [ ] Java ???
- [ ] Julia ???
- [ ] Kokkos
- [ ] OpenCL
- [X] OpenMP
- [ ] Raja
- [ ] Rust ???
- [ ] Scala
- [ ] std-data (C++ stdpar)
- [ ] std-indices (C++ stdpar)
- [ ] std-ranges (C++ stdpar)
- [ ] SYCL
- [ ] SYCL 2020
- [ ] TBB
- [ ] Thrust

