### PR TITLE
Reflect updated model options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The source for each model's implementations are located in `./src/<model>`.
 
 Currently available models are:
 ```
-omp;ocl;std;std20;hip;cuda;kokkos;sycl;sycl2020;acc;raja;tbb;thrust
+omp;ocl;std-data;std-indices;std-ranges;hip;cuda;kokkos;sycl;sycl2020;acc;raja;tbb;thrust
 ```
 
 #### Overriding default flags


### PR DESCRIPTION
I noticed the README was out of date with the current model options available by BabelStream. I did not implement any further changes.