### PR TITLE
accept NVHPC NVC++ as a CUDA compiler when it is so

### DIFF
--- a/src/thrust/ThrustStream.cu
+++ b/src/thrust/ThrustStream.cu
@@ -145,7 +145,7 @@ T ThrustStream<T>::dot()
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA || \
     (defined(THRUST_DEVICE_SYSTEM_HIP) && THRUST_DEVICE_SYSTEM_HIP == THRUST_DEVICE_SYSTEM)
 
-#ifdef __NVCC__
+#if defined(__NVCC__) || defined(__NVCOMPILER_CUDA__)
 #define IMPL_FN__(fn) cuda ## fn
 #define IMPL_TYPE__(tpe) cuda ## tpe
 #elif defined(__HIP_PLATFORM_HCC__)


### PR DESCRIPTION
fixes https://github.com/UoB-HPC/BabelStream/issues/142 except for the CMake part, which i attempted in vain to address.

Signed-off-by: Jeff Hammond <jehammond@nvidia.com>