### PR TITLE
Fix RAJA > v0.14.1 compatibility

### DIFF
--- a/src/raja/model.cmake
+++ b/src/raja/model.cmake
@@ -8,6 +8,8 @@ register_flag_optional(RAJA_IN_TREE
          Make sure to use the release version of RAJA or clone RAJA recursively with submodules.
          Remember to append RAJA specific flags as well, for example:
              -DRAJA_IN_TREE=... -DENABLE_OPENMP=ON -DENABLE_CUDA=ON ...
+         For RAJA >= v2022.03.0, remember to use the RAJA prefixed CMake options:
+             -DRAJA_IN_TREE=... -DRAJA_ENABLE_OPENMP=ON -DRAJA_ENABLE_CUDA=ON ...
          See https://github.com/LLNL/RAJA/blob/08cbbafd2d21589ebf341f7275c229412d0fe903/CMakeLists.txt#L44 for all available options
 " "")
 
@@ -20,7 +22,7 @@ register_flag_optional(TARGET
         CPU)
 
 register_flag_optional(CUDA_TOOLKIT_ROOT_DIR
-        "[TARGET==NVIDIA only] Path to the CUDA toolkit directory (e.g `/opt/cuda-11.2`) if the ENABLE_CUDA flag is specified for RAJA" "")
+        "[TARGET==NVIDIA only] Path to the CUDA toolkit directory (e.g `/opt/cuda-11.2`) if the RAJA_ENABLE_CUDA or ENABLE_CUDA flag is specified for RAJA" "")
 
 # XXX CMake 3.18 supports CMAKE_CUDA_ARCHITECTURES/CUDA_ARCHITECTURES but we support older CMakes
 register_flag_optional(CUDA_ARCH
@@ -58,7 +60,20 @@ macro(setup)
         set(ENABLE_BENCHMARKS OFF CACHE BOOL "")
         set(ENABLE_CUDA ${ENABLE_CUDA} CACHE BOOL "" FORCE)
 
-        if (ENABLE_CUDA)
+        # RAJA >= v2022.03.0 switched to prefixed variables, we keep the legacy ones for backwards compatibiity
+        set(RAJA_ENABLE_TESTS OFF CACHE BOOL "")
+        set(RAJA_ENABLE_EXAMPLES OFF CACHE BOOL "")
+        set(RAJA_ENABLE_REPRODUCERS OFF CACHE BOOL "")
+        set(RAJA_ENABLE_EXERCISES OFF CACHE BOOL "")
+        set(RAJA_ENABLE_DOCUMENTATION OFF CACHE BOOL "")
+        set(RAJA_ENABLE_BENCHMARKS OFF CACHE BOOL "")
+        set(RAJA_ENABLE_CUDA ${RAJA_ENABLE_CUDA} CACHE BOOL "" FORCE)
+
+        if (ENABLE_CUDA OR RAJA_ENABLE_CUDA)
+
+            # RAJA still needs ENABLE_CUDA for internal use, so if either is on, assert both.
+            set(RAJA_ENABLE_CUDA ON)
+            set(ENABLE_CUDA ON)
 
             # XXX CMake 3.18 supports CMAKE_CUDA_ARCHITECTURES/CUDA_ARCHITECTURES but we support older CMakes
             if(POLICY CMP0104)
@@ -69,6 +84,10 @@ macro(setup)
             set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc)
             set(CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS} "-forward-unknown-to-host-compiler -extended-lambda -arch=${CUDA_ARCH}" ${CUDA_EXTRA_FLAGS})
             list(APPEND CMAKE_CUDA_FLAGS)
+
+            # See https://github.com/LLNL/RAJA/pull/1302
+            # And https://github.com/LLNL/RAJA/pull/1339
+            set(RAJA_ENABLE_VECTORIZATION OFF CACHE BOOL "")
 
             message(STATUS "NVCC flags: ${CMAKE_CUDA_FLAGS}")
         endif ()


### PR DESCRIPTION
Project now compiles with both v0.14.1 and v2022.10.5, tested with OpenMP and CUDA.
This addresses #114 .