### PR TITLE
std-indices: Capture in offload-friendly way

### DIFF
--- a/src/std-indices/STDIndicesStream.cpp
+++ b/src/std-indices/STDIndicesStream.cpp
@@ -49,7 +49,8 @@ template <class T>
 void STDIndicesStream<T>::mul()
 {
   //  b[i] = scalar * c[i];
-  std::transform(exe_policy, range.begin(), range.end(), b.begin(), [=, scalar = startScalar](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), b.begin(),
+                 [c = c.data(), scalar = startScalar](int i) {
     return scalar * c[i];
   });
 }
@@ -58,7 +59,8 @@ template <class T>
 void STDIndicesStream<T>::add()
 {
   //  c[i] = a[i] + b[i];
-  std::transform(exe_policy, range.begin(), range.end(), c.begin(), [=](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), c.begin(),
+                 [a = a.data(), b = b.data()](int i) {
     return a[i] + b[i];
   });
 }
@@ -67,7 +69,8 @@ template <class T>
 void STDIndicesStream<T>::triad()
 {
   //  a[i] = b[i] + scalar * c[i];
-  std::transform(exe_policy, range.begin(), range.end(), a.begin(), [=, scalar = startScalar](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), a.begin(),
+                 [b = b.data(), c = c.data(), scalar = startScalar](int i) {
     return b[i] + scalar * c[i];
   });
 }
@@ -79,7 +82,8 @@ void STDIndicesStream<T>::nstream()
   //  Need to do in two stages with C++11 STL.
   //  1: a[i] += b[i]
   //  2: a[i] += scalar * c[i];
-  std::transform(exe_policy, range.begin(), range.end(), a.begin(), [=, scalar = startScalar](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), a.begin(),
+                 [a = a.data(), b = b.data(), c = c.data(), scalar = startScalar](int i) {
     return a[i] + b[i] + scalar * c[i];
   });
 }

--- a/src/std-indices/STDIndicesStream.cpp
+++ b/src/std-indices/STDIndicesStream.cpp
@@ -49,7 +49,7 @@ template <class T>
 void STDIndicesStream<T>::mul()
 {
   //  b[i] = scalar * c[i];
-  std::transform(exe_policy, range.begin(), range.end(), b.begin(), [&, scalar = startScalar](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), b.begin(), [=, scalar = startScalar](int i) {
     return scalar * c[i];
   });
 }
@@ -58,7 +58,7 @@ template <class T>
 void STDIndicesStream<T>::add()
 {
   //  c[i] = a[i] + b[i];
-  std::transform(exe_policy, range.begin(), range.end(), c.begin(), [&](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), c.begin(), [=](int i) {
     return a[i] + b[i];
   });
 }
@@ -67,7 +67,7 @@ template <class T>
 void STDIndicesStream<T>::triad()
 {
   //  a[i] = b[i] + scalar * c[i];
-  std::transform(exe_policy, range.begin(), range.end(), a.begin(), [&, scalar = startScalar](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), a.begin(), [=, scalar = startScalar](int i) {
     return b[i] + scalar * c[i];
   });
 }
@@ -79,7 +79,7 @@ void STDIndicesStream<T>::nstream()
   //  Need to do in two stages with C++11 STL.
   //  1: a[i] += b[i]
   //  2: a[i] += scalar * c[i];
-  std::transform(exe_policy, range.begin(), range.end(), a.begin(), [&, scalar = startScalar](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), a.begin(), [=, scalar = startScalar](int i) {
     return a[i] + b[i] + scalar * c[i];
   });
 }


### PR DESCRIPTION
Previously, std-indices captured by reference. In an offload scenario, capture-by-value is generally preferred because if the reference points to stack memory on the host, offloaded kernels will encounter illegal memory accesses. This is also something that compilers generally cannot remedy using magic compiler transformations to make data GPU-accessible -- this only works for the heap.

The current code only works in an offload scenario, because the stream class itself is allocated on the heap (which compilers can then make GPU-accessible), and the kernels can then reference the `std::vector` objects for the data.

As I've said, this relies on an implementation detail and may be brittle in case the architecture ever changes, or someone wishes to reuse babelstream code in a different context.

This PR therefore attempts to make things more robust by directly capturing data pointers by value.

On Intel iGPU, I see no substantial performance difference between the two versions in an offload scenario.
