### PR TITLE
Update README.md to Address Changes in SYCL2020 Renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The source for each model's implementations are located in `./src/<model>`.
 
 Currently available models are:
 ```
-omp;ocl;std-data;std-indices;std-ranges;hip;cuda;kokkos;sycl;sycl2020;acc;raja;tbb;thrust;futhark
+omp;ocl;std-data;std-indices;std-ranges;hip;cuda;kokkos;sycl;sycl2020-acc;sycl2020-usm;acc;raja;tbb;thrust;futhark
 ```
 
 #### Overriding default flags


### PR DESCRIPTION
The sycl2020 model variant name needs an update to comply with naming scheme in Babelstream 5.0