### PR TITLE
Remove AdaptiveCpp workaround in dpl_shim.h to allow for automatic prefetch optimization

### DIFF
--- a/src/dpl_shim.h
+++ b/src/dpl_shim.h
@@ -55,22 +55,10 @@ static constexpr auto exe_policy = std::execution::par_unseq;
 #endif
 
 #ifdef USE_STD_PTR_ALLOC_DEALLOC
-
-#if defined(__HIPSYCL__) || defined(__OPENSYCL__)
-#include <CL/sycl.hpp>
-
-// TODO We temporarily use malloc_shared/free here for hipSYCL stdpar because there's a linking issue if we let it hijack new/delete
-//  for this to work, we compile with --hipsycl-stdpar-system-usm so that hijacking is disabled
-static cl::sycl::queue queue{cl::sycl::default_selector_v};
-template <typename T> T *alloc_raw(size_t size) { return cl::sycl::malloc_shared<T>(size, queue); }
-template <typename T> void dealloc_raw(T *ptr) { cl::sycl::free(ptr, queue); }
-
-#else
 template<typename T>
 T *alloc_raw(size_t size) { return (T *) aligned_alloc(ALIGNMENT, sizeof(T) * size); }
 
 template<typename T>
 void dealloc_raw(T *ptr) { free(ptr); }
-#endif
 
 #endif


### PR DESCRIPTION
To my knowledge, the AdaptiveCpp-specific workaround in `dpl_shim.h` is no longer necessary as the linking issue was fixed some time ago.

Additionally, this workaround prevents a new optmization in AdaptiveCpp stdpar from taking place: AdaptiveCpp stdpar can now emit automatic data prefetches. But this only works, if the data is managed by the stdpar runtime, which tracks pointers it knows. If `sycl::malloc_shared` is used directly, the stdpar optimizations do not recognize the pointer and won't apply the optimization.
(the reasoning being that if someone calls SYCL functionality directly, they might want to exert more control and emit prefetches or `mem_advise` operations by themselves).

Other projects which also use this header like cloverleaf are also affected. Will create a PR there too.