### PR TITLE
Support array_sizes that are not divisible by the thread block size for CUDA and HIP

### DIFF
--- a/src/cuda/CUDAStream.cu
+++ b/src/cuda/CUDAStream.cu
@@ -16,6 +16,7 @@
 // The do while is there to make sure you remember to put a semi-colon after calling CU
 #define CU(EXPR) do { auto __e = (EXPR); if (__e != cudaSuccess) error(__FILE__, __LINE__, #EXPR, __e); } while(false)
 
+// It is best practice to include __device__ and constexpr even though in BabelStream it only needs to be __host__ const
 __host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + b - 1)/b; }
 
 cudaStream_t stream;

--- a/src/cuda/CUDAStream.cu
+++ b/src/cuda/CUDAStream.cu
@@ -15,6 +15,8 @@
 
 #define CU(EXPR) if (auto __e = (EXPR); __e != cudaSuccess) error(__FILE__, __LINE__, #EXPR, __e);
 
+__host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + b - 1)/b; }
+
 template <class T>
 CUDAStream<T>::CUDAStream(const int ARRAY_SIZE, const int device_index)
 {
@@ -107,7 +109,8 @@ __global__ void init_kernel(T * a, T * b, T * c, T initA, T initB, T initC, int 
 template <class T>
 void CUDAStream<T>::init_arrays(T initA, T initB, T initC)
 {
-  init_kernel<<<array_size/TBSIZE, TBSIZE>>>(d_a, d_b, d_c, initA, initB, initC, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  init_kernel<<<blocks, TBSIZE>>>(d_a, d_b, d_c, initA, initB, initC, array_size);
   CU(cudaPeekAtLastError());
   CU(cudaDeviceSynchronize());
 }
@@ -143,7 +146,8 @@ __global__ void copy_kernel(const T * a, T * c, int array_size)
 template <class T>
 void CUDAStream<T>::copy()
 {
-  copy_kernel<<<array_size/TBSIZE, TBSIZE>>>(d_a, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  copy_kernel<<<blocks, TBSIZE>>>(d_a, d_c, array_size);
   CU(cudaPeekAtLastError());
   CU(cudaDeviceSynchronize());
 }
@@ -160,7 +164,8 @@ __global__ void mul_kernel(T * b, const T * c, int array_size)
 template <class T>
 void CUDAStream<T>::mul()
 {
-  mul_kernel<<<array_size/TBSIZE, TBSIZE>>>(d_b, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  mul_kernel<<<blocks, TBSIZE>>>(d_b, d_c, array_size);
   CU(cudaPeekAtLastError());
   CU(cudaDeviceSynchronize());
 }
@@ -176,7 +181,8 @@ __global__ void add_kernel(const T * a, const T * b, T * c, int array_size)
 template <class T>
 void CUDAStream<T>::add()
 {
-  add_kernel<<<array_size/TBSIZE, TBSIZE>>>(d_a, d_b, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  add_kernel<<<blocks, TBSIZE>>>(d_a, d_b, d_c, array_size);
   CU(cudaPeekAtLastError());  
   CU(cudaDeviceSynchronize());
 }
@@ -193,7 +199,8 @@ __global__ void triad_kernel(T * a, const T * b, const T * c, int array_size)
 template <class T>
 void CUDAStream<T>::triad()
 {
-  triad_kernel<<<array_size/TBSIZE, TBSIZE>>>(d_a, d_b, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  triad_kernel<<<blocks, TBSIZE>>>(d_a, d_b, d_c, array_size);
   CU(cudaPeekAtLastError());
   CU(cudaDeviceSynchronize());
 }
@@ -210,7 +217,8 @@ __global__ void nstream_kernel(T * a, const T * b, const T * c, int array_size)
 template <class T>
 void CUDAStream<T>::nstream()
 {
-  nstream_kernel<<<array_size/TBSIZE, TBSIZE>>>(d_a, d_b, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  nstream_kernel<<<blocks, TBSIZE>>>(d_a, d_b, d_c, array_size);
   CU(cudaPeekAtLastError());
   CU(cudaDeviceSynchronize());
 }

--- a/src/cuda/CUDAStream.cu
+++ b/src/cuda/CUDAStream.cu
@@ -13,6 +13,7 @@
   exit(e);
 }
 
+// The do while is there to make sure you remember to put a semi-colon after calling CU
 #define CU(EXPR) do { auto __e = (EXPR); if (__e != cudaSuccess) error(__FILE__, __LINE__, #EXPR, __e); } while(false)
 
 __host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + b - 1)/b; }

--- a/src/cuda/CUDAStream.cu
+++ b/src/cuda/CUDAStream.cu
@@ -13,7 +13,7 @@
   exit(e);
 }
 
-#define CU(EXPR) if (auto __e = (EXPR); __e != cudaSuccess) error(__FILE__, __LINE__, #EXPR, __e);
+#define CU(EXPR) do { auto __e = (EXPR); if (__e != cudaSuccess) error(__FILE__, __LINE__, #EXPR, __e); } while(false)
 
 __host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + b - 1)/b; }
 

--- a/src/cuda/model.cmake
+++ b/src/cuda/model.cmake
@@ -22,6 +22,7 @@ register_flag_optional(CUDA_EXTRA_FLAGS
 
 
 macro(setup)
+    set(CMAKE_CUDA_STANDARD 17)
 
     # XXX CMake 3.18 supports CMAKE_CUDA_ARCHITECTURES/CUDA_ARCHITECTURES but we support older CMakes
     if(POLICY CMP0104)

--- a/src/cuda/model.cmake
+++ b/src/cuda/model.cmake
@@ -22,7 +22,6 @@ register_flag_optional(CUDA_EXTRA_FLAGS
 
 
 macro(setup)
-    set(CMAKE_CUDA_STANDARD 17)
 
     # XXX CMake 3.18 supports CMAKE_CUDA_ARCHITECTURES/CUDA_ARCHITECTURES but we support older CMakes
     if(POLICY CMP0104)

--- a/src/hip/HIPStream.cpp
+++ b/src/hip/HIPStream.cpp
@@ -21,6 +21,7 @@ void check_error(void)
   }
 }
 
+// It is best practice to include __device__ and constexpr even though in BabelStream it only needs to be __host__ const
 __host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + b - 1)/b; }
 
 template <class T>

--- a/src/hip/HIPStream.cpp
+++ b/src/hip/HIPStream.cpp
@@ -24,15 +24,6 @@ void check_error(void)
 template <class T>
 HIPStream<T>::HIPStream(const int ARRAY_SIZE, const int device_index)
 {
-
-  // The array size must be divisible by TBSIZE for kernel launches
-  if (ARRAY_SIZE % TBSIZE != 0)
-  {
-    std::stringstream ss;
-    ss << "Array size must be a multiple of " << TBSIZE;
-    throw std::runtime_error(ss.str());
-  }
-
   // Set device
   int count;
   hipGetDeviceCount(&count);
@@ -74,7 +65,7 @@ HIPStream<T>::HIPStream(const int ARRAY_SIZE, const int device_index)
   if (props.totalGlobalMem < std::size_t{3}*ARRAY_SIZE*sizeof(T))
     throw std::runtime_error("Device does not have enough memory for all 3 buffers");
 
- // Create device buffers
+  // Create device buffers
 #if defined(MANAGED)
   hipMallocManaged(&d_a, array_bytes);
   check_error();
@@ -113,18 +104,19 @@ HIPStream<T>::~HIPStream()
 
 
 template <typename T>
-__global__ void init_kernel(T * a, T * b, T * c, T initA, T initB, T initC)
+__global__ void init_kernel(T * a, T * b, T * c, T initA, T initB, T initC, int array_size)
 {
-  const size_t i = blockDim.x * blockIdx.x + threadIdx.x;
-  a[i] = initA;
-  b[i] = initB;
-  c[i] = initC;
+  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+    a[i] = initA;
+    b[i] = initB;
+    c[i] = initC;
+  }
 }
 
 template <class T>
 void HIPStream<T>::init_arrays(T initA, T initB, T initC)
 {
-  init_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, initA, initB, initC);
+  init_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, initA, initB, initC, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
@@ -154,83 +146,89 @@ void HIPStream<T>::read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector
 }
 
 template <typename T>
-__global__ void copy_kernel(const T * a, T * c)
+__global__ void copy_kernel(const T * a, T * c, int array_size)
 {
-  const size_t i = threadIdx.x + blockIdx.x * blockDim.x;
-  c[i] = a[i];
+  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+    c[i] = a[i];
+  }
 }
 
 template <class T>
 void HIPStream<T>::copy()
 {
-  copy_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_c);
+  copy_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
 }
 
 template <typename T>
-__global__ void mul_kernel(T * b, const T * c)
+__global__ void mul_kernel(T * b, const T * c, int array_size)
 {
   const T scalar = startScalar;
-  const size_t i = threadIdx.x + blockIdx.x * blockDim.x;
-  b[i] = scalar * c[i];
+  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+    b[i] = scalar * c[i];
+  }
 }
 
 template <class T>
 void HIPStream<T>::mul()
 {
-  mul_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_b, d_c);
+  mul_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_b, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
 }
 
 template <typename T>
-__global__ void add_kernel(const T * a, const T * b, T * c)
+__global__ void add_kernel(const T * a, const T * b, T * c, int array_size)
 {
   const size_t i = threadIdx.x + blockIdx.x * blockDim.x;
-  c[i] = a[i] + b[i];
+  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+    c[i] = a[i] + b[i];
+  }
 }
 
 template <class T>
 void HIPStream<T>::add()
 {
-  add_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c);
+  add_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
 }
 
 template <typename T>
-__global__ void triad_kernel(T * a, const T * b, const T * c)
+__global__ void triad_kernel(T * a, const T * b, const T * c, int array_size)
 {
   const T scalar = startScalar;
-  const size_t i = threadIdx.x + blockIdx.x * blockDim.x;
-  a[i] = b[i] + scalar * c[i];
+  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+    a[i] = b[i] + scalar * c[i];
+  }
 }
 
 template <class T>
 void HIPStream<T>::triad()
 {
-  triad_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c);
+  triad_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
 }
 
 template <typename T>
-__global__ void nstream_kernel(T * a, const T * b, const T * c)
+__global__ void nstream_kernel(T * a, const T * b, const T * c, int array_size)
 {
   const T scalar = startScalar;
-  const size_t i = threadIdx.x + blockIdx.x * blockDim.x;
-  a[i] += b[i] + scalar * c[i];
+  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+    a[i] += b[i] + scalar * c[i];
+  }
 }
 
 template <class T>
 void HIPStream<T>::nstream()
 {
-  nstream_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c);
+  nstream_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();

--- a/src/hip/HIPStream.cpp
+++ b/src/hip/HIPStream.cpp
@@ -21,6 +21,8 @@ void check_error(void)
   }
 }
 
+__host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + b - 1)/b; }
+
 template <class T>
 HIPStream<T>::HIPStream(const int ARRAY_SIZE, const int device_index)
 {
@@ -116,7 +118,8 @@ __global__ void init_kernel(T * a, T * b, T * c, T initA, T initB, T initC, int 
 template <class T>
 void HIPStream<T>::init_arrays(T initA, T initB, T initC)
 {
-  init_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, initA, initB, initC, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  init_kernel<T><<<dim3(blocks), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, initA, initB, initC, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
@@ -156,7 +159,8 @@ __global__ void copy_kernel(const T * a, T * c, int array_size)
 template <class T>
 void HIPStream<T>::copy()
 {
-  copy_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  copy_kernel<T><<<dim3(blocks), dim3(TBSIZE), 0, 0>>>(d_a, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
@@ -174,7 +178,8 @@ __global__ void mul_kernel(T * b, const T * c, int array_size)
 template <class T>
 void HIPStream<T>::mul()
 {
-  mul_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_b, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  mul_kernel<T><<<dim3(blocks), dim3(TBSIZE), 0, 0>>>(d_b, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
@@ -192,7 +197,8 @@ __global__ void add_kernel(const T * a, const T * b, T * c, int array_size)
 template <class T>
 void HIPStream<T>::add()
 {
-  add_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  add_kernel<T><<<dim3(blocks), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
@@ -210,7 +216,8 @@ __global__ void triad_kernel(T * a, const T * b, const T * c, int array_size)
 template <class T>
 void HIPStream<T>::triad()
 {
-  triad_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  triad_kernel<T><<<dim3(blocks), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();
@@ -228,7 +235,8 @@ __global__ void nstream_kernel(T * a, const T * b, const T * c, int array_size)
 template <class T>
 void HIPStream<T>::nstream()
 {
-  nstream_kernel<T><<<dim3(array_size/TBSIZE), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, array_size);
+  size_t blocks = ceil_div(array_size, TBSIZE);
+  nstream_kernel<T><<<dim3(blocks), dim3(TBSIZE), 0, 0>>>(d_a, d_b, d_c, array_size);
   check_error();
   hipDeviceSynchronize();
   check_error();


### PR DESCRIPTION
Currently, CUDA and HIP do not support array sizes that are not divisible by the thread block size, Since most other programming models support these, this PR removes this limitation to improve BabelStream's fairness.

This is done using a technique that is widely used in practice, commonly known as a "grid-strided loop" (see [CUDA Pro Tip: Write Flexible Kernels with Grid-Stride Loops](https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/)). The number of thread blocks in the launch configuration is rounded up to cover all array elements using `ceil_div`.

This PR also updates the CUDAStream implementation to modern CUDA C++ practices by simplifying error handling, and using an explicit `cudaStream_t`. The impact of these two changes on performance is negligible; they are only cosmetic changes.