### PR TITLE
Improvements to main.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ endmacro()
 # the final executable name
 set(EXE_NAME babelstream)
 
-# for chrono and some basic CXX features, models can overwrite this if required
-set(CMAKE_CXX_STANDARD 11)
+# for chrono, some basic CXX features, and generic lambdas; models can overwrite this if required
+set(CMAKE_CXX_STANDARD 14)
 
 if (NOT CMAKE_BUILD_TYPE)
     message("No CMAKE_BUILD_TYPE specified, defaulting to 'Release'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ endmacro()
 # the final executable name
 set(EXE_NAME babelstream)
 
-# for chrono and some basic CXX features, models can overwrite this if required
-set(CMAKE_CXX_STANDARD 11)
+# for chrono, make_unique, and some basic CXX features, models can overwrite this if required
+set(CMAKE_CXX_STANDARD 14)
 
 if (NOT CMAKE_BUILD_TYPE)
     message("No CMAKE_BUILD_TYPE specified, defaulting to 'Release'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ endmacro()
 # the final executable name
 set(EXE_NAME babelstream)
 
-# for chrono, some basic CXX features, and generic lambdas; models can overwrite this if required
-set(CMAKE_CXX_STANDARD 14)
+# for chrono and some basic CXX features, models can overwrite this if required
+set(CMAKE_CXX_STANDARD 11)
 
 if (NOT CMAKE_BUILD_TYPE)
     message("No CMAKE_BUILD_TYPE specified, defaulting to 'Release'")

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -20,7 +20,6 @@ template <class T>
 class Stream
 {
   public:
-
     virtual ~Stream(){}
 
     // Kernels
@@ -35,9 +34,7 @@ class Stream
     // Copy memory between host and device
     virtual void init_arrays(T initA, T initB, T initC) = 0;
     virtual void read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector<T>& c) = 0;
-
 };
-
 
 // Implementation specific device functions
 void listDevices(void);

--- a/src/StreamModels.h
+++ b/src/StreamModels.h
@@ -36,66 +36,66 @@
 #endif
 
 template <typename T>
-std::unique_ptr<Stream<T>> make_stream(int ARRAY_SIZE, unsigned int deviceIndex) {
+std::unique_ptr<Stream<T>> make_stream(int array_size, int deviceIndex) {
 #if defined(CUDA)
   // Use the CUDA implementation
-  return std::make_unique<CUDAStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<CUDAStream<T>>(array_size, deviceIndex);
 
 #elif defined(HIP)
   // Use the HIP implementation
-  return std::make_unique<HIPStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<HIPStream<T>>(array_size, deviceIndex);
 
 #elif defined(HC)
   // Use the HC implementation
-  return std::make_unique<HCStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<HCStream<T>>(array_size, deviceIndex);
 
 #elif defined(OCL)
   // Use the OpenCL implementation
-  return std::make_unique<OCLStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<OCLStream<T>>(array_size, deviceIndex);
 
 #elif defined(USE_RAJA)
   // Use the RAJA implementation
-  return std::make_unique<RAJAStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<RAJAStream<T>>(array_size, deviceIndex);
 
 #elif defined(KOKKOS)
   // Use the Kokkos implementation
-  return std::make_unique<KokkosStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<KokkosStream<T>>(array_size, deviceIndex);
 
 #elif defined(STD_DATA)
   // Use the C++ STD data-oriented implementation
-  return std::make_unique<STDDataStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<STDDataStream<T>>(array_size, deviceIndex);
 
 #elif defined(STD_INDICES)
   // Use the C++ STD index-oriented implementation
-  return std::make_unique<STDIndicesStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<STDIndicesStream<T>>(array_size, deviceIndex);
 
 #elif defined(STD_RANGES)
   // Use the C++ STD ranges implementation
-  return std::make_unique<STDRangesStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<STDRangesStream<T>>(array_size, deviceIndex);
 
 #elif defined(TBB)
   // Use the C++20 implementation
-  return std::make_unique<TBBStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<TBBStream<T>>(array_size, deviceIndex);
 
 #elif defined(THRUST)
   // Use the Thrust implementation
-  return std::make_unique<ThrustStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<ThrustStream<T>>(array_size, deviceIndex);
 
 #elif defined(ACC)
   // Use the OpenACC implementation
-  return std::make_unique<ACCStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<ACCStream<T>>(array_size, deviceIndex);
 
 #elif defined(SYCL) || defined(SYCL2020)
   // Use the SYCL implementation
-  return std::make_unique<SYCLStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<SYCLStream<T>>(array_size, deviceIndex);
 
 #elif defined(OMP)
   // Use the OpenMP implementation
-  return std::make_unique<OMPStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<OMPStream<T>>(array_size, deviceIndex);
 
 #elif defined(FUTHARK)
   // Use the Futhark implementation
-  return std::make_unique<FutharkStream<T>>(ARRAY_SIZE, deviceIndex);
+  return std::make_unique<FutharkStream<T>>(array_size, deviceIndex);
 
 #else
 

--- a/src/StreamModels.h
+++ b/src/StreamModels.h
@@ -36,7 +36,7 @@
 #endif
 
 template <typename T>
-std::unique_ptr<Stream<T>> construct_stream(int ARRAY_SIZE, unsigned int deviceIndex) {
+std::unique_ptr<Stream<T>> make_stream(int ARRAY_SIZE, unsigned int deviceIndex) {
 #if defined(CUDA)
   // Use the CUDA implementation
   return std::make_unique<CUDAStream<T>>(ARRAY_SIZE, deviceIndex);

--- a/src/StreamModels.h
+++ b/src/StreamModels.h
@@ -1,0 +1,105 @@
+#pragma once
+#include <memory>
+
+#if defined(CUDA)
+#include "CUDAStream.h"
+#elif defined(STD_DATA)
+#include "STDDataStream.h"
+#elif defined(STD_INDICES)
+#include "STDIndicesStream.h"
+#elif defined(STD_RANGES)
+#include "STDRangesStream.hpp"
+#elif defined(TBB)
+#include "TBBStream.hpp"
+#elif defined(THRUST)
+#include "ThrustStream.h"
+#elif defined(HIP)
+#include "HIPStream.h"
+#elif defined(HC)
+#include "HCStream.h"
+#elif defined(OCL)
+#include "OCLStream.h"
+#elif defined(USE_RAJA)
+#include "RAJAStream.hpp"
+#elif defined(KOKKOS)
+#include "KokkosStream.hpp"
+#elif defined(ACC)
+#include "ACCStream.h"
+#elif defined(SYCL)
+#include "SYCLStream.h"
+#elif defined(SYCL2020)
+#include "SYCLStream2020.h"
+#elif defined(OMP)
+#include "OMPStream.h"
+#elif defined(FUTHARK)
+#include "FutharkStream.h"
+#endif
+
+template <typename T>
+std::unique_ptr<Stream<T>> construct_stream(int ARRAY_SIZE, unsigned int deviceIndex) {
+#if defined(CUDA)
+  // Use the CUDA implementation
+  return std::make_unique<CUDAStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(HIP)
+  // Use the HIP implementation
+  return std::make_unique<HIPStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(HC)
+  // Use the HC implementation
+  return std::make_unique<HCStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(OCL)
+  // Use the OpenCL implementation
+  return std::make_unique<OCLStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(USE_RAJA)
+  // Use the RAJA implementation
+  return std::make_unique<RAJAStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(KOKKOS)
+  // Use the Kokkos implementation
+  return std::make_unique<KokkosStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(STD_DATA)
+  // Use the C++ STD data-oriented implementation
+  return std::make_unique<STDDataStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(STD_INDICES)
+  // Use the C++ STD index-oriented implementation
+  return std::make_unique<STDIndicesStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(STD_RANGES)
+  // Use the C++ STD ranges implementation
+  return std::make_unique<STDRangesStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(TBB)
+  // Use the C++20 implementation
+  return std::make_unique<TBBStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(THRUST)
+  // Use the Thrust implementation
+  return std::make_unique<ThrustStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(ACC)
+  // Use the OpenACC implementation
+  return std::make_unique<ACCStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(SYCL) || defined(SYCL2020)
+  // Use the SYCL implementation
+  return std::make_unique<SYCLStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(OMP)
+  // Use the OpenMP implementation
+  return std::make_unique<OMPStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#elif defined(FUTHARK)
+  // Use the Futhark implementation
+  return std::make_unique<FutharkStream<T>>(ARRAY_SIZE, deviceIndex);
+
+#else
+
+  #error unknown benchmark
+
+#endif
+}

--- a/src/Unit.h
+++ b/src/Unit.h
@@ -1,51 +1,31 @@
 #pragma once
 #include <iostream>
 
-enum { MegaByte, GigaByte, MibiByte, GibiByte };
-
 // Units for output:
 struct Unit {
-  int value;
-  Unit(int v) : value(v) {}
-  double fmt(double bytes) {
+  enum class Kind { MegaByte, GigaByte, TeraByte, MibiByte, GibiByte, TebiByte };
+  Kind value;
+  explicit Unit(Kind v) : value(v) {}
+  double fmt(double bytes) const {
     switch(value) {
-    case MibiByte: return pow(2.0, -20.0) * bytes;
-    case MegaByte: return 1.0E-6 * bytes;
-    case GibiByte: return pow(2.0, -30.0) * bytes;
-    case GigaByte: return 1.0E-9 * bytes;
-    default: std::cerr << "Unimplemented!" << std::endl; abort();
+    case Kind::MibiByte: return std::pow(2.0, -20.0) * bytes;
+    case Kind::MegaByte: return 1.0E-6 * bytes;
+    case Kind::GibiByte: return std::pow(2.0, -30.0) * bytes;
+    case Kind::GigaByte: return 1.0E-9 * bytes;
+    case Kind::TebiByte: return std::pow(2.0, -40.0) * bytes;
+    case Kind::TeraByte: return 1.0E-12 * bytes;      
+    default: std::cerr << "Unimplemented!" << std::endl; std::abort();
     }
   }
-  char const* str() {
+  char const* str() const {
     switch(value) {
-    case MibiByte: return "MiB";
-    case MegaByte: return "MB";
-    case GibiByte: return "GiB";
-    case GigaByte: return "GB";
-    default: std::cerr << "Unimplemented!" << std::endl; abort();
-    }
-  }
-  Unit kibi() {
-    switch(value) {
-    case MegaByte: return Unit(MibiByte);
-    case GigaByte: return Unit(GibiByte);
-    default: return *this;
-    }
-  }
-  Unit byte() {
-    switch(value) {
-    case MibiByte: return Unit(MegaByte);
-    case GibiByte: return Unit(GigaByte);
-    default: return *this;
-    }
-  }
-  char const* lower() {
-    switch(value) {
-    case MibiByte: return "mibytes";
-    case MegaByte: return "mbytes";
-    case GibiByte: return "gibytes";
-    case GigaByte: return "gbytes";
-    default: std::cerr << "Unimplemented!" << std::endl; abort();
+    case Kind::MibiByte: return "MiB";
+    case Kind::MegaByte: return "MB";
+    case Kind::GibiByte: return "GiB";
+    case Kind::GigaByte: return "GB";
+    case Kind::TebiByte: return "TiB";
+    case Kind::TeraByte: return "TB";
+    default: std::cerr << "Unimplemented!" << std::endl; std::abort();
     }
   }
 };

--- a/src/Unit.h
+++ b/src/Unit.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <iostream>
+
+enum { MegaByte, GigaByte, MibiByte, GibiByte };
+
+// Units for output:
+struct Unit {
+  int value;
+  Unit(int v) : value(v) {}
+  double fmt(double bytes) {
+    switch(value) {
+    case MibiByte: return pow(2.0, -20.0) * bytes;
+    case MegaByte: return 1.0E-6 * bytes;
+    case GibiByte: return pow(2.0, -30.0) * bytes;
+    case GigaByte: return 1.0E-9 * bytes;
+    default: std::cerr << "Unimplemented!" << std::endl; abort();
+    }
+  }
+  char const* str() {
+    switch(value) {
+    case MibiByte: return "MiB";
+    case MegaByte: return "MB";
+    case GibiByte: return "GiB";
+    case GigaByte: return "GB";
+    default: std::cerr << "Unimplemented!" << std::endl; abort();
+    }
+  }
+  Unit kibi() {
+    switch(value) {
+    case MegaByte: return Unit(MibiByte);
+    case GigaByte: return Unit(GibiByte);
+    default: return *this;
+    }
+  }
+  Unit byte() {
+    switch(value) {
+    case MibiByte: return Unit(MegaByte);
+    case GibiByte: return Unit(GigaByte);
+    default: return *this;
+    }
+  }
+  char const* lower() {
+    switch(value) {
+    case MibiByte: return "mibytes";
+    case MegaByte: return "mbytes";
+    case GibiByte: return "gibytes";
+    case GigaByte: return "gbytes";
+    default: std::cerr << "Unimplemented!" << std::endl; abort();
+    }
+  }
+};

--- a/src/Unit.h
+++ b/src/Unit.h
@@ -4,7 +4,9 @@
 // Units for output:
 struct Unit {
   enum class Kind { MegaByte, GigaByte, TeraByte, MibiByte, GibiByte, TebiByte };
+
   Kind value;
+  
   explicit Unit(Kind v) : value(v) {}
 
   double fmt(double bytes) const {

--- a/src/Unit.h
+++ b/src/Unit.h
@@ -6,6 +6,7 @@ struct Unit {
   enum class Kind { MegaByte, GigaByte, TeraByte, MibiByte, GibiByte, TebiByte };
   Kind value;
   explicit Unit(Kind v) : value(v) {}
+
   double fmt(double bytes) const {
     switch(value) {
     case Kind::MibiByte: return std::pow(2.0, -20.0) * bytes;

--- a/src/Unit.h
+++ b/src/Unit.h
@@ -17,6 +17,7 @@ struct Unit {
     default: std::cerr << "Unimplemented!" << std::endl; std::abort();
     }
   }
+
   char const* str() const {
     switch(value) {
     case Kind::MibiByte: return "MiB";

--- a/src/cuda/CUDAStream.cu
+++ b/src/cuda/CUDAStream.cu
@@ -1,10 +1,8 @@
-
 // Copyright (c) 2015-16 Tom Deakin, Simon McIntosh-Smith,
 // University of Bristol HPC
 //
 // For full license terms please see the LICENSE file distributed with this
 // source code
-
 
 #include "CUDAStream.h"
 
@@ -17,12 +15,13 @@
 #define CU(EXPR) do { auto __e = (EXPR); if (__e != cudaSuccess) error(__FILE__, __LINE__, #EXPR, __e); } while(false)
 
 // It is best practice to include __device__ and constexpr even though in BabelStream it only needs to be __host__ const
-__host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + b - 1)/b; }
+__host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + b - 1) / b; }
 
 cudaStream_t stream;
 
 template <class T>
-CUDAStream<T>::CUDAStream(const int ARRAY_SIZE, const int device_index)
+CUDAStream<T>::CUDAStream(const int array_size, const int device_index)
+  : array_size(array_size)
 {
   // Set device
   int count;
@@ -43,20 +42,16 @@ CUDAStream<T>::CUDAStream(const int ARRAY_SIZE, const int device_index)
 #else
   std::cout << "Memory: DEFAULT" << std::endl;
 #endif
-  array_size = ARRAY_SIZE;
-
 
   // Query device for sensible dot kernel block count
   cudaDeviceProp props;
   CU(cudaGetDeviceProperties(&props, device_index));
   dot_num_blocks = props.multiProcessorCount * 4;
 
-  // Allocate the host array for partial sums for dot kernels
-  sums = (T*)malloc(sizeof(T) * dot_num_blocks);
-
-  size_t array_bytes = sizeof(T);
-  array_bytes *= ARRAY_SIZE;
-  size_t total_bytes = array_bytes * 4;
+  // Size of partial sums for dot kernels
+  size_t sums_bytes = sizeof(T) * dot_num_blocks;
+  size_t array_bytes = sizeof(T) * array_size;
+  size_t total_bytes = array_bytes * size_t(3) + sums_bytes;
   std::cout << "Reduction kernel config: " << dot_num_blocks << " groups of (fixed) size " << TBSIZE << std::endl;
 
   // Check buffers fit on the device
@@ -68,45 +63,42 @@ CUDAStream<T>::CUDAStream(const int ARRAY_SIZE, const int device_index)
   CU(cudaMallocManaged(&d_a, array_bytes));
   CU(cudaMallocManaged(&d_b, array_bytes));
   CU(cudaMallocManaged(&d_c, array_bytes));
-  CU(cudaMallocManaged(&d_sum, dot_num_blocks*sizeof(T)));
+  CU(cudaHostAlloc(&sums, sums_bytes, cudaHostAllocDefault));
 #elif defined(PAGEFAULT)
   d_a = (T*)malloc(array_bytes);
   d_b = (T*)malloc(array_bytes);
   d_c = (T*)malloc(array_bytes);
-  d_sum = (T*)malloc(sizeof(T)*dot_num_blocks);
+  sums = (T*)malloc(sums_bytes);
 #else
   CU(cudaMalloc(&d_a, array_bytes));
   CU(cudaMalloc(&d_b, array_bytes));
   CU(cudaMalloc(&d_c, array_bytes));
-  CU(cudaMalloc(&d_sum, dot_num_blocks*sizeof(T)));
+  CU(cudaHostAlloc(&sums, sums_bytes, cudaHostAllocDefault));
 #endif
 }
-
 
 template <class T>
 CUDAStream<T>::~CUDAStream()
 {
   CU(cudaStreamDestroy(stream));
-  free(sums);
 
 #if defined(PAGEFAULT)
   free(d_a);
   free(d_b);
   free(d_c);
-  free(d_sum);
+  free(sums);
 #else
   CU(cudaFree(d_a));
   CU(cudaFree(d_b));
   CU(cudaFree(d_c));
-  CU(cudaFree(d_sum));
+  CU(cudaFreeHost(sums));
 #endif
 }
-
 
 template <typename T>
 __global__ void init_kernel(T * a, T * b, T * c, T initA, T initB, T initC, int array_size)
 {  
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
     a[i] = initA;
     b[i] = initB;
     c[i] = initC;
@@ -128,7 +120,7 @@ void CUDAStream<T>::read_arrays(std::vector<T>& a, std::vector<T>& b, std::vecto
   // Copy device memory to host
 #if defined(PAGEFAULT) || defined(MANAGED)
   CU(cudaStreamSynchronize(stream));
-  for (int i = 0; i < array_size; i++)
+  for (int i = 0; i < array_size; ++i)
   {
     a[i] = d_a[i];
     b[i] = d_b[i];
@@ -141,11 +133,10 @@ void CUDAStream<T>::read_arrays(std::vector<T>& a, std::vector<T>& b, std::vecto
 #endif
 }
 
-
 template <typename T>
 __global__ void copy_kernel(const T * a, T * c, int array_size)
 {
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
     c[i] = a[i];
   }
 }
@@ -163,7 +154,7 @@ template <typename T>
 __global__ void mul_kernel(T * b, const T * c, int array_size)
 {
   const T scalar = startScalar;
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
     b[i] = scalar * c[i];
   }
 }
@@ -180,7 +171,7 @@ void CUDAStream<T>::mul()
 template <typename T>
 __global__ void add_kernel(const T * a, const T * b, T * c, int array_size)
 {
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
     c[i] = a[i] + b[i];
   }
 }
@@ -198,7 +189,7 @@ template <typename T>
 __global__ void triad_kernel(T * a, const T * b, const T * c, int array_size)
 {
   const T scalar = startScalar;
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
     a[i] = b[i] + scalar * c[i];
   }
 }
@@ -216,7 +207,7 @@ template <typename T>
 __global__ void nstream_kernel(T * a, const T * b, const T * c, int array_size)
 {
   const T scalar = startScalar;
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
     a[i] += b[i] + scalar * c[i];
   }
 }
@@ -231,50 +222,33 @@ void CUDAStream<T>::nstream()
 }
 
 template <class T>
-__global__ void dot_kernel(const T * a, const T * b, T * sum, int array_size)
+__global__ void dot_kernel(const T * a, const T * b, T* sums, int array_size)
 {
-  __shared__ T tb_sum[TBSIZE];
+  __shared__ T smem[TBSIZE];
+  T tmp = T(0.);
+  const size_t tidx = threadIdx.x;
+  for (int i = tidx + (size_t)blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+    tmp += a[i] * b[i];
+  }
+  smem[tidx] = tmp;
 
-  int i = blockDim.x * blockIdx.x + threadIdx.x;
-  const size_t local_i = threadIdx.x;
-
-  tb_sum[local_i] = {};
-  for (; i < array_size; i += blockDim.x*gridDim.x)
-    tb_sum[local_i] += a[i] * b[i];
-
-  for (int offset = blockDim.x / 2; offset > 0; offset /= 2)
-  {
+  for (int offset = blockDim.x / 2; offset > 0; offset /= 2) {
     __syncthreads();
-    if (local_i < offset)
-    {
-      tb_sum[local_i] += tb_sum[local_i+offset];
-    }
+    if (tidx < offset) smem[tidx] += smem[tidx+offset];
   }
 
-  if (local_i == 0)
-    sum[blockIdx.x] = tb_sum[local_i];
+  if (tidx == 0) sums[blockIdx.x] = smem[tidx];
 }
 
 template <class T>
 T CUDAStream<T>::dot()
 {
-  dot_kernel<<<dot_num_blocks, TBSIZE, 0, stream>>>(d_a, d_b, d_sum, array_size);
+  dot_kernel<<<dot_num_blocks, TBSIZE, 0, stream>>>(d_a, d_b, sums, array_size);
   CU(cudaPeekAtLastError());
-
-#if !(defined(MANAGED) || defined(PAGEFAULT))
-  CU(cudaMemcpyAsync(sums, d_sum, dot_num_blocks*sizeof(T), cudaMemcpyDeviceToHost, stream));
-#endif
   CU(cudaStreamSynchronize(stream));
 
   T sum = 0.0;
-  for (int i = 0; i < dot_num_blocks; i++)
-  {
-#if defined(MANAGED) || defined(PAGEFAULT)
-    sum += d_sum[i];
-#else
-    sum += sums[i];
-#endif
-  }
+  for (int i = 0; i < dot_num_blocks; ++i) sum += sums[i];
 
   return sum;
 }
@@ -302,14 +276,12 @@ void listDevices(void)
   }
 }
 
-
 std::string getDeviceName(const int device)
 {
   cudaDeviceProp props;
   CU(cudaGetDeviceProperties(&props, device));
   return std::string(props.name);
 }
-
 
 std::string getDeviceDriver(const int device)
 {

--- a/src/cuda/CUDAStream.cu
+++ b/src/cuda/CUDAStream.cu
@@ -237,6 +237,7 @@ __global__ void dot_kernel(const T * a, const T * b, T* sums, int array_size)
     if (tidx < offset) smem[tidx] += smem[tidx+offset];
   }
 
+  // First thread writes to host memory directly from the device
   if (tidx == 0) sums[blockIdx.x] = smem[tidx];
 }
 

--- a/src/cuda/CUDAStream.h
+++ b/src/cuda/CUDAStream.h
@@ -31,13 +31,11 @@ class CUDAStream : public Stream<T>
     T *d_a;
     T *d_b;
     T *d_c;
-    T *d_sum;
 
     // Number of blocks for dot kernel
     int dot_num_blocks;
 
   public:
-
     CUDAStream(const int, const int);
     ~CUDAStream();
 
@@ -50,5 +48,4 @@ class CUDAStream : public Stream<T>
 
     virtual void init_arrays(T initA, T initB, T initC) override;
     virtual void read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector<T>& c) override;
-
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@ array<size_t, num_benchmarks> weight = {/*Copy:*/ 2, /*Add:*/ 2, /*Mul:*/ 3, /*T
 enum class Benchmark : int {Copy = 0, Add = 1, Mul = 2, Triad = 3, Dot = 4, Nstream = 5, Classic, All};
 
 // Selected run options.
-Benchmark selection = Benchmark::All;
+Benchmark selection = Benchmark::Classic;
 
 // Returns true if the benchmark needs to be run:
 bool run_benchmark(int id) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,64 +23,50 @@
 
 // Default size of 2^25
 int ARRAY_SIZE = 33554432;
-unsigned int num_times = 100;
-unsigned int deviceIndex = 0;
+size_t num_times = 100;
+size_t deviceIndex = 0;
 bool use_float = false;
 bool output_as_csv = false;
 Unit unit{Unit::Kind::MegaByte};
 bool silence_errors = false;
 std::string csv_separator = ",";
 
-// Benchmarks:
-constexpr size_t num_benchmarks = 6;
-std::array<char const*, num_benchmarks> labels = {"Copy", "Add", "Mul", "Triad", "Dot", "Nstream"};
-// Weights data moved by benchmark & therefore achieved BW:
-// bytes = weight * sizeof(T) * ARRAY_SIZE -> bw = bytes / dur
-std::array<size_t, num_benchmarks> weight = {/*Copy:*/ 2, /*Add:*/ 2, /*Mul:*/ 3, /*Triad:*/ 3, /*Dot:*/ 2, /*Nstream:*/ 4};
-
-// Options for running the benchmark:
-// - Classic 5 kernels (Copy, Add, Mul, Triad, Dot).
-// - All kernels (Copy, Add, Mul, Triad, Dot, Nstream).
+// Benchmark Identifier: identifies individual & groups of benchmarks:
+// - Classic: 5 classic kernels: Copy, Mul, Add, Triad, Dot.
+// - All: all kernels.
 // - Individual kernels only.
-enum class Benchmark : int {Copy = 0, Add = 1, Mul = 2, Triad = 3, Dot = 4, Nstream = 5, Classic, All};
+enum class BenchId : int {Copy, Mul, Add, Triad, Nstream, Dot, Classic, All};
 
-// Selected run options.
-Benchmark selection = Benchmark::Classic;
+struct Benchmark {
+  BenchId id;
+  char const* label;
+  // Weights data moved by benchmark & therefore achieved BW:
+  // bytes = weight * sizeof(T) * ARRAY_SIZE -> bw = bytes / dur
+  size_t weight;
+  // Is it one of: Copy, Mul, Add, Triad, Dot?
+  bool classic = false;
+};
+
+// Benchmarks in the order in which - if present - should be run for validation purposes:
+constexpr size_t num_benchmarks = 6;
+std::array<Benchmark, num_benchmarks> bench = {
+  Benchmark { .id = BenchId::Copy,    .label = "Copy",    .weight = 2, .classic = true  },
+  Benchmark { .id = BenchId::Mul,     .label = "Mul",     .weight = 2, .classic = true  },
+  Benchmark { .id = BenchId::Add,     .label = "Add",     .weight = 3, .classic = true  },
+  Benchmark { .id = BenchId::Triad,   .label = "Triad",   .weight = 3, .classic = true  },
+  Benchmark { .id = BenchId::Dot,     .label = "Dot",     .weight = 2, .classic = true  },
+  Benchmark { .id = BenchId::Nstream, .label = "Nstream", .weight = 4, .classic = false }
+};
+
+// Selected benchmarks to run: default is all 5 classic benchmarks.
+BenchId selection = BenchId::Classic;
 
 // Returns true if the benchmark needs to be run:
-bool run_benchmark(int id) {
-  if (selection == Benchmark::All)                return true;
-  if (selection == Benchmark::Classic && id < 5)  return true;
-  if (id == 0 && selection == Benchmark::Copy)    return true;
-  if (id == 1 && selection == Benchmark::Add)     return true;
-  if (id == 2 && selection == Benchmark::Mul)     return true;
-  if (id == 3 && selection == Benchmark::Triad)   return true;
-  if (id == 4 && selection == Benchmark::Dot)     return true;
-  if (id == 5 && selection == Benchmark::Nstream) return true;
-  return false;
+bool run_benchmark(Benchmark const& b) {
+  if (selection == BenchId::All)                  return true;
+  if (selection == BenchId::Classic && b.classic) return true;
+  return selection == b.id;
 }
-
-// Prints all available benchmark labels:
-template <typename OStream>
-void print_labels(OStream& os) {
-  for (size_t i = 0; i < num_benchmarks; ++i) {
-    os << labels[i];
-    if (i != (num_benchmarks - 1)) os << ",";
-  }
-}
-
-// Returns duration of executing function f:
-template <typename F>
-double time(F&& f) {
-  using clk_t = std::chrono::high_resolution_clock;
-  using dur_t = std::chrono::duration<double>;
-  auto start = clk_t::now();
-  f();
-  return dur_t(clk_t::now() - start).count();
-}
-
-template <typename T>
-void check_solution(const unsigned int ntimes, std::vector<T>& a, std::vector<T>& b, std::vector<T>& c, T& sum);
 
 template <typename T>
 void run();
@@ -89,7 +75,6 @@ void parseArguments(int argc, char *argv[]);
 
 int main(int argc, char *argv[])
 {
-
   parseArguments(argc, argv);
 
   if (!output_as_csv)
@@ -108,26 +93,35 @@ int main(int argc, char *argv[])
   return EXIT_SUCCESS;
 }
 
+// Returns duration of executing function f:
+template <typename F>
+double time(F&& f) {
+  using clk_t = std::chrono::high_resolution_clock;
+  using dur_t = std::chrono::duration<double>;
+  auto start = clk_t::now();
+  f();
+  return dur_t(clk_t::now() - start).count();
+}
+
 // Run specified kernels
 template <typename T>
-
 std::vector<std::vector<double>> run_all(std::unique_ptr<Stream<T>>& stream, T& sum)
 {
   // Times for each measured benchmark:
   std::vector<std::vector<double>> timings(num_benchmarks);
 
   // Time a particular benchmark:
-  auto dt = [&](size_t i)
+  auto dt = [&](Benchmark const& b)
   {
-    switch((Benchmark)i) {
-    case Benchmark::Copy:    return time([&] { stream->copy(); });
-    case Benchmark::Mul:     return time([&] { stream->mul(); });
-    case Benchmark::Add:     return time([&] { stream->add(); });
-    case Benchmark::Triad:   return time([&] { stream->triad(); });
-    case Benchmark::Dot:     return time([&] { sum  = stream->dot(); });
-    case Benchmark::Nstream: return time([&] { stream->nstream(); });
+    switch(b.id) {
+    case BenchId::Copy:    return time([&] { stream->copy(); });
+    case BenchId::Mul:     return time([&] { stream->mul(); });
+    case BenchId::Add:     return time([&] { stream->add(); });
+    case BenchId::Triad:   return time([&] { stream->triad(); });
+    case BenchId::Dot:     return time([&] { sum = stream->dot(); });
+    case BenchId::Nstream: return time([&] { stream->nstream(); });
     default:
-      std::cerr << "Unimplemented benchmark: " << i << "," <<  labels[i] << std::endl;
+      std::cerr << "Unimplemented benchmark: " << b.label << std::endl;
       abort();
     }
   };
@@ -135,14 +129,18 @@ std::vector<std::vector<double>> run_all(std::unique_ptr<Stream<T>>& stream, T& 
   // Main loop
   for (size_t i = 0; i < num_benchmarks; ++i)
   {
-    if (!run_benchmark(i)) continue;
+    if (!run_benchmark(bench[i])) continue;
     timings[i].reserve(num_times);
-    for (unsigned int k = 0; k < num_times; k++) timings[i].push_back(dt(i));
+    for (size_t k = 0; k < num_times; k++) timings[i].push_back(dt(bench[i]));
   }
 
   // Compiler should use a move
   return timings;
 }
+
+template <typename T>
+void check_solution(const size_t ntimes, std::vector<T>& a, std::vector<T>& b, std::vector<T>& c,
+		    T& sum);
 
 // Generic run routine
 // Runs the kernel(s) and prints output.
@@ -167,7 +165,8 @@ void run()
       << "avg_runtime" << std::endl;
   };
   auto fmt_csv = [](char const* function, size_t num_times, size_t num_elements,
-                    size_t type_size, double bandwidth, double dt_min, double dt_max, double dt_avg) {
+                    size_t type_size, double bandwidth,
+		    double dt_min, double dt_max, double dt_avg) {
     std::cout << function << csv_separator
          << num_times << csv_separator
          << num_elements << csv_separator
@@ -177,7 +176,8 @@ void run()
          << dt_max << csv_separator
          << dt_avg << std::endl;
   };
-  auto fmt_cli = [](char const* function, double bandwidth, double dt_min, double dt_max, double dt_avg) {
+  auto fmt_cli = [](char const* function, double bandwidth,
+		    double dt_min, double dt_max, double dt_avg) {
     std::cout
       << std::left << std::setw(12) << function
       << std::left << std::setw(12) << std::setprecision(3) << bandwidth
@@ -187,7 +187,8 @@ void run()
       << std::endl;
   };
   auto fmt_result = [&](char const* function, size_t num_times, size_t num_elements,
-                        size_t type_size, double bandwidth, double dt_min, double dt_max, double dt_avg) {
+                        size_t type_size, double bandwidth,
+			double dt_min, double dt_max, double dt_avg) {
     if (!output_as_csv) return fmt_cli(function, bandwidth, dt_min, dt_max, dt_avg);
     fmt_csv(function, num_times, num_elements, type_size, bandwidth, dt_min, dt_max, dt_avg);
   };
@@ -196,22 +197,30 @@ void run()
   {
     std::cout << "Running ";
     switch(selection) {
-    case Benchmark::All: std::cout << " All kernels "; break;
-    case Benchmark::Classic: std::cout << " Classic kernels "; break;
-    default: std::cout << "Running " << labels[(int)selection] << " ";
+    case BenchId::All: std::cout << " All kernels "; break;
+    case BenchId::Classic: std::cout << " Classic kernels "; break;
+    default:
+      std::cout << "Running ";
+      for (size_t i = 0; i < num_benchmarks; ++i) {
+	if (selection == bench[i].id) {
+	  std::cout << bench[i].label;
+	  break;
+	}
+      }
+      std::cout << " ";
     }
     std::cout << num_times << " times" << std::endl;
     std::cout << "Number of elements: " << ARRAY_SIZE << std::endl;
     std::cout << "Precision: " << (sizeof(T) == sizeof(float)? "float" : "double") << std::endl;
 
-    size_t nbytes = ARRAY_SIZE*sizeof(T);
+    size_t nbytes = ARRAY_SIZE * sizeof(T);
     std::cout << std::setprecision(1) << std::fixed
-	 << "Array size: " << unit.fmt(nbytes) << " " << unit.str() << std::endl;
+	      << "Array size: " << unit.fmt(nbytes) << " " << unit.str() << std::endl;
     std::cout << "Total size: " << unit.fmt(3.0*nbytes) << " " << unit.str() << std::endl;
     std::cout.precision(ss);
   }
 
-  auto stream = make_stream<T>(ARRAY_SIZE, deviceIndex);
+  std::unique_ptr<Stream<T>> stream = make_stream<T>(ARRAY_SIZE, deviceIndex);
   auto initElapsedS = time([&] { stream->init_arrays(startA, startB, startC); });
 
   // Result of the Dot kernel, if used.
@@ -251,111 +260,115 @@ void run()
       << std::fixed;
   }
 
-  for (int i = 0; i < num_benchmarks; ++i)
+  for (size_t i = 0; i < num_benchmarks; ++i)
   {
-    if (!run_benchmark(i)) continue;
+    if (!run_benchmark(bench[i])) continue;
 
     // Get min/max; ignore the first result
     auto minmax = std::minmax_element(timings[i].begin()+1, timings[i].end());
 
     // Calculate average; ignore the first result
-    double average = std::accumulate(timings[i].begin()+1, timings[i].end(), 0.0) / (double)(num_times - 1);
+    double average = std::accumulate(timings[i].begin()+1, timings[i].end(), 0.0)
+      / (double)(num_times - 1);
 
     // Display results
-    fmt_result(labels[i], num_times, ARRAY_SIZE, sizeof(T), fmt_bw(weight[i], *minmax.first),
-               *minmax.first, *minmax.second, average);
+    fmt_result(bench[i].label, num_times, ARRAY_SIZE, sizeof(T),
+	       fmt_bw(bench[i].weight, *minmax.first), *minmax.first, *minmax.second, average);
   }
 }
 
 template <typename T>
-void check_solution(const unsigned int ntimes, std::vector<T>& a, std::vector<T>& b, std::vector<T>& c, T& sum)
+void check_solution(const size_t num_times,
+		    std::vector<T>& a, std::vector<T>& b, std::vector<T>& c, T& sum)
 {
   // Generate correct solution
   T goldA = startA;
   T goldB = startB;
   T goldC = startC;
-  T goldSum{};
+  T goldS = T(0.);
 
   const T scalar = startScalar;
 
   for (size_t b = 0; b < num_benchmarks; ++b)
   {
-    if (!run_benchmark(b)) continue;
+    if (!run_benchmark(bench[b])) continue;
 
-    for (unsigned int i = 0; i < ntimes; i++)
+    for (size_t i = 0; i < num_times; i++)
     {
-      switch(static_cast<Benchmark>(b)) {
-      case Benchmark::Copy:    goldC = goldA; break;
-      case Benchmark::Mul:     goldB = scalar * goldC; break;
-      case Benchmark::Add:     goldC = goldA + goldB; break;
-      case Benchmark::Triad:   goldA = goldB + scalar * goldC; break;
-      case Benchmark::Nstream: goldA += goldB + scalar * goldC; break;
-      case Benchmark::Dot:     goldSum = goldA * goldB * ARRAY_SIZE; break;
-      default: std::cerr << "Unimplemented Check: " << i << "," << labels[b] << std::endl; abort();
+      switch(bench[b].id) {
+      case BenchId::Copy:    goldC = goldA; break;
+      case BenchId::Mul:     goldB = scalar * goldC; break;
+      case BenchId::Add:     goldC = goldA + goldB; break;
+      case BenchId::Triad:   goldA = goldB + scalar * goldC; break;
+      case BenchId::Nstream: goldA += goldB + scalar * goldC; break;
+      case BenchId::Dot:     goldS = goldA * goldB * T(ARRAY_SIZE); break;
+      default:
+	std::cerr << "Unimplemented Check: " << bench[b].label << std::endl;
+	abort();
       }
     }
   }
 
-  // Calculate the average error
-  long double errA = std::accumulate(a.begin(), a.end(), T{}, [&](double sum, const T val){ return sum + std::fabs(val - goldA); });
-  errA /= a.size();
-  long double errB = std::accumulate(b.begin(), b.end(), T{}, [&](double sum, const T val){ return sum + std::fabs(val - goldB); });
-  errB /= b.size();
-  long double errC = std::accumulate(c.begin(), c.end(), T{}, [&](double sum, const T val){ return sum + std::fabs(val - goldC); });
-  errC /= c.size();
-  long double errSum = std::fabs((sum - goldSum)/goldSum);
+  // Error relative tolerance check
+  size_t failed = 0;
+  T epsi = std::numeric_limits<T>::epsilon() * T(100000.0);
+  auto check = [&](const char* name, T is, T should, T e, size_t i = size_t(-1)) {
+    if (e > epsi) {
+      ++failed;
+      if (failed > 10) return;
+      std::cerr << "FAILED validation of " << name;
+      if (i != size_t(-1)) std::cerr << "[" << i << "]";
+      std::cerr << ": " << is << " != " << should
+		<< ", relative error=" << e << " > " << epsi << std::endl;
+    }
+  };
 
-  long double epsi = std::numeric_limits<T>::epsilon() * 1000.0;
-
-  bool failed = false;
-  if (errA > epsi) {
-    failed = true;
-    std::cerr
-      << "Validation failed on a[]. Average error " << errA
-      << std::endl;
-  }
-  if (errB > epsi) {
-    failed = true;
-    std::cerr
-      << "Validation failed on b[]. Average error " << errB
-      << std::endl;
-  }
-  if (errC > epsi) {
-    failed = true;
-    std::cerr
-      << "Validation failed on c[]. Average error " << errC
-      << std::endl;
-  }
-  // Check sum to 8 decimal places
-  if (selection == Benchmark::All && errSum > epsi) {
-    failed = true;
-    std::cerr
-      << "Validation failed on sum. Error " << errSum
-      << std::endl << std::setprecision(15)
-      << "Sum was " << sum << " but should be " << goldSum
-      << std::endl;
+  // Sum
+  T eS = std::fabs(sum - goldS) / std::fabs(goldS);
+  for (size_t i = 0; i < num_benchmarks; ++i) {
+    if (bench[i].id != BenchId::Dot) continue;
+    if (run_benchmark(bench[i]))
+      check("sum", sum,  goldS, eS);
+    break;
   }
 
-  if (failed && !silence_errors)
+  // Calculate the L^infty-norm relative error
+  for (size_t i = 0; i < a.size(); ++i) {
+    T vA = a[i], vB = b[i], vC = c[i];
+    T eA = std::fabs(vA - goldA) / std::fabs(goldA);
+    T eB = std::fabs(vB - goldB) / std::fabs(goldB);
+    T eC = std::fabs(vC - goldC) / std::fabs(goldC);
+
+    check("a", a[i], goldA, eA, i);
+    check("b", b[i], goldB, eB, i);
+    check("c", c[i], goldC, eC, i);
+  }
+
+  if (failed > 0 && !silence_errors)
     std::exit(EXIT_FAILURE);
-}
-
-int parseUInt(const char *str, unsigned int *output)
-{
-  char *next;
-  *output = strtoul(str, &next, 10);
-  return !strlen(next);
-}
-
-int parseInt(const char *str, int *output)
-{
-  char *next;
-  *output = strtol(str, &next, 10);
-  return !strlen(next);
 }
 
 void parseArguments(int argc, char *argv[])
 {
+  auto parseUInt =[](const char *str, size_t *output) {
+    char *next;
+    *output = strtoull(str, &next, 10);
+    return !strlen(next);
+  };
+  auto parseInt =[](const char *str, intptr_t *output) {
+    char *next;
+    *output = strtoll(str, &next, 10);
+    return !strlen(next);
+  };
+
+  // Prints all available benchmark labels:
+  auto print_labels = [&](auto& os) {
+    for (size_t i = 0; i < num_benchmarks; ++i) {
+      os << bench[i].label;
+      if (i != (num_benchmarks - 1)) os << ",";
+    }
+  };
+
   for (int i = 1; i < argc; i++)
   {
     if (!std::string("--list").compare(argv[i]))
@@ -374,11 +387,13 @@ void parseArguments(int argc, char *argv[])
     else if (!std::string("--arraysize").compare(argv[i]) ||
              !std::string("-s").compare(argv[i]))
     {
-      if (++i >= argc || !parseInt(argv[i], &ARRAY_SIZE) || ARRAY_SIZE <= 0)
+      intptr_t array_size;
+      if (++i >= argc || !parseInt(argv[i], &array_size) || array_size <= 0)
       {
         std::cerr << "Invalid array size." << std::endl;
         exit(EXIT_FAILURE);
       }
+      ARRAY_SIZE = array_size;
     }
     else if (!std::string("--numtimes").compare(argv[i]) ||
              !std::string("-n").compare(argv[i]))
@@ -415,25 +430,25 @@ void parseArguments(int argc, char *argv[])
       auto key = std::string(argv[i]);
       if (key == "Classic")
       {
-        selection = Benchmark::Classic;
+        selection = BenchId::Classic;
       }
       else if (key == "All")
       {
-        selection = Benchmark::All;
+        selection = BenchId::All;
       }
       else
       {
-        auto p = std::find_if(labels.begin(), labels.end(), [&](char const* label) {
-            return std::string(label) == key;
-          });
-        if (p == labels.end()) {
+        auto p = std::find_if(bench.begin(), bench.end(), [&](Benchmark const& b) {
+	  return std::string(b.label) == key;
+        });
+        if (p == bench.end()) {
           std::cerr << "Unknown benchmark name \"" << argv[i] << "\" after --only" << std::endl;
-          std::cerr << "Available benchmarks: All,Classic,";
+          std::cerr << "Available benchmarks: All, Classic,";
           print_labels(std::cerr);
           std::cerr << std::endl;
 	  std::exit(EXIT_FAILURE);
         }
-        selection = (Benchmark)(std::distance(labels.begin(), p));
+        selection = p->id;
       }
     }
     else if (!std::string("--csv").compare(argv[i]))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -414,13 +414,43 @@ void parseArguments(int argc, char *argv[])
     {
       use_float = true;
     }
-    else if (!std::string("--triad-only").compare(argv[i]))
+    else if (!std::string("--print-names").compare(argv[i]))
     {
-      selection = Benchmark::Triad;
+      std::cout << "Available benchmarks: ";
+      print_labels(std::cout);
+      std::cout << std::endl;
+      exit(EXIT_SUCCESS);
     }
-    else if (!std::string("--nstream-only").compare(argv[i]))
+    else if (!std::string("--only").compare(argv[i]) || !std::string("-o").compare(argv[i]))
     {
-      selection = Benchmark::Nstream;
+      if (++i >= argc)
+      {
+	std::cerr << "Expected benchmark name after --only" << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      auto key = string(argv[i]);
+      if (key == "Classic")
+      {
+        selection = Benchmark::Classic;
+      }
+      else if (key == "All")
+      {
+        selection = Benchmark::All;
+      }
+      else
+      {
+        auto p = find_if(labels.begin(), labels.end(), [&](char const* label) {
+            return string(label) == key;
+          });
+        if (p == labels.end()) {
+          std::cerr << "Unknown benchmark name \"" << argv[i] << "\" after --only" << std::endl;
+          std::cerr << "Available benchmarks: All,Classic,";
+          print_labels(std::cerr);
+          std::cerr << std::endl;
+	  std::exit(EXIT_FAILURE);
+        }
+        selection = (Benchmark)(distance(labels.begin(), p));
+      }
     }
     else if (!std::string("--csv").compare(argv[i]))
     {
@@ -442,18 +472,18 @@ void parseArguments(int argc, char *argv[])
       std::cout << "  -s  --arraysize  SIZE    Use SIZE elements in the array" << std::endl;
       std::cout << "  -n  --numtimes   NUM     Run the test NUM times (NUM >= 2)" << std::endl;
       std::cout << "      --float              Use floats (rather than doubles)" << std::endl;
-      std::cout << "      --triad-only         Only run triad" << std::endl;
-      std::cout << "      --nstream-only       Only run nstream" << std::endl;
+      std::cout << "  -o  --only       NAME    Only run one benchmark (see --print-names)" << std::endl;
+      std::cout << "      --print-names        Prints all available benchmark names" << std::endl;
       std::cout << "      --csv                Output as csv table" << std::endl;
       std::cout << "      --mibibytes          Use MiB=2^20 for bandwidth calculation (default MB=10^6)" << std::endl;
       std::cout << std::endl;
-      exit(EXIT_SUCCESS);
+      std::exit(EXIT_SUCCESS);
     }
     else
     {
       std::cerr << "Unrecognized argument '" << argv[i] << "' (try '--help')"
                 << std::endl;
-      exit(EXIT_FAILURE);
+      std::exit(EXIT_FAILURE);
     }
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,15 +5,15 @@
 // For full license terms please see the LICENSE file distributed with this
 // source code
 
-#include <iostream>
-#include <vector>
-#include <numeric>
-#include <cmath>
-#include <limits>
-#include <chrono>
 #include <algorithm>
-#include <iomanip>
+#include <chrono>
+#include <cmath>
 #include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <numeric>
+#include <vector>
 
 #define VERSION_STRING "5.0"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -569,7 +569,7 @@ void parseArguments(int argc, char *argv[])
       std::cout << "      --csv                Output as csv table" << std::endl;
       std::cout << "      --megabytes          Use MB=10^6 for bandwidth calculation (default)" << std::endl;
       std::cout << "      --mibibytes          Use MiB=2^20 for bandwidth calculation (default MB=10^6)" << std::endl;
-      std::cout << "      --gigibytes          Use GiB=2^30 for bandwidth calculation (default MB=10^6)" << std::endl;
+      std::cout << "      --gibibytes          Use GiB=2^30 for bandwidth calculation (default MB=10^6)" << std::endl;
       std::cout << "      --gigabytes          Use GB=10^9 for bandwidth calculation (default MB=10^6)" << std::endl;
       std::cout << "      --tebibytes          Use TiB=2^40 for bandwidth calculation (default MB=10^6)" << std::endl;
       std::cout << "      --terabytes          Use TB=10^12 for bandwidth calculation (default MB=10^6)" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -409,7 +409,7 @@ void parseArguments(int argc, char *argv[])
     *output = strtoull(str, &next, 10);
     return !strlen(next);
   };
-  auto parseInt =[](const char *str, intptr_t *output) {
+  auto parseInt = [](const char *str, intptr_t *output) {
     char *next;
     *output = strtoll(str, &next, 10);
     return !strlen(next);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ enum class BenchId : int {Copy, Mul, Add, Triad, Nstream, Dot, Classic, All};
 struct Benchmark {
   BenchId id;
   char const* label;
-  // Weights data moved by benchmark & therefore achieved BW:
+  // Weight counts data elements of original arrays moved each loop iteration - used to calculate achieved BW:
   // bytes = weight * sizeof(T) * ARRAY_SIZE -> bw = bytes / dur
   size_t weight;
   // Is it one of: Copy, Mul, Add, Triad, Dot?

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -331,7 +331,7 @@ void check_solution(const size_t num_times,
     case BenchId::Add:     goldC = goldA + goldB; break;
     case BenchId::Triad:   goldA = goldB + scalar * goldC; break;
     case BenchId::Nstream: goldA += goldB + scalar * goldC; break;
-    case BenchId::Dot:     goldS = goldA * goldB * T(ARRAY_SIZE); break;
+    case BenchId::Dot:     goldS = goldA * goldB * T(ARRAY_SIZE); break; // This calculates the answer exactly
     default:
     std::cerr << "Unimplemented Check: " << bench[b].label << std::endl;
     abort();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -445,7 +445,7 @@ void parseArguments(int argc, char *argv[])
       if (++i >= argc || !parseInt(argv[i], &array_size) || array_size <= 0)
       {
         std::cerr << "Invalid array size." << std::endl;
-        exit(EXIT_FAILURE);
+        std::exit(EXIT_FAILURE);
       }
       ARRAY_SIZE = array_size;
     }
@@ -472,14 +472,14 @@ void parseArguments(int argc, char *argv[])
       std::cout << "Available benchmarks: ";
       print_labels(std::cout);
       std::cout << std::endl;
-      exit(EXIT_SUCCESS);
+      std::exit(EXIT_SUCCESS);
     }
     else if (!std::string("--only").compare(argv[i]) || !std::string("-o").compare(argv[i]))
     {
       if (++i >= argc)
       {
-	std::cerr << "Expected benchmark name after --only" << std::endl;
-        exit(EXIT_FAILURE);
+        std::cerr << "Expected benchmark name after --only" << std::endl;
+        std::exit(EXIT_FAILURE);
       }
       auto key = std::string(argv[i]);
       if (key == "Classic")
@@ -493,14 +493,14 @@ void parseArguments(int argc, char *argv[])
       else
       {
         auto p = std::find_if(bench.begin(), bench.end(), [&](Benchmark const& b) {
-	  return std::string(b.label) == key;
+          return std::string(b.label) == key;
         });
         if (p == bench.end()) {
           std::cerr << "Unknown benchmark name \"" << argv[i] << "\" after --only" << std::endl;
           std::cerr << "Available benchmarks: All, Classic,";
           print_labels(std::cerr);
           std::cerr << std::endl;
-	  std::exit(EXIT_FAILURE);
+          std::exit(EXIT_FAILURE);
         }
         selection = p->id;
       }
@@ -509,7 +509,7 @@ void parseArguments(int argc, char *argv[])
     {
       if (++i >= argc)
       {
-	std::cerr << "Expected benchmark order after --order. Options: \"classic\" (default), \"isolated\"."
+       std::cerr << "Expected benchmark order after --order. Options: \"classic\" (default), \"isolated\"."
 		  << std::endl;
         exit(EXIT_FAILURE);
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ size_t num_times = 100;
 size_t deviceIndex = 0;
 bool use_float = false;
 bool output_as_csv = false;
+// Default unit of memory is MegaBytes (as per STREAM) 
 Unit unit{Unit::Kind::MegaByte};
 bool silence_errors = false;
 std::string csv_separator = ",";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -344,8 +344,8 @@ void check_solution(const size_t num_times,
   case BenchOrder::Classic: {
     for (size_t k = 0; k < num_times; k++) {
       for (size_t i = 0; i < num_benchmarks; ++i) {
-	if (!run_benchmark(bench[i])) continue;
-	run(i);
+	      if (!run_benchmark(bench[i])) continue;
+	      run(i);
       }
     }
     break;

--- a/src/omp/model.cmake
+++ b/src/omp/model.cmake
@@ -151,7 +151,7 @@ macro(setup)
         # offload but OFFLOAD_FLAGS overrides
         register_definitions(OMP_TARGET_GPU)
         separate_arguments(OFFLOAD_FLAGS)
-        list(OMP_FLAGS APPEND ${OFFLOAD_FLAGS})
+        list(APPEND OMP_FLAGS ${OFFLOAD_FLAGS})
     else ()
 
         # handle the vendor:arch value


### PR DESCRIPTION
This PR gives a pass to `main.cpp` to make it much easier to add newer benchmarks in the future.

Main changes are:
- `--only` option enables specifying different groups or individual benchmarks, e.g., `--only Classic` runs the classic 5 benchmarks, `--only All` runs all benchmarks (e.g. including nstream), and `--only Triad` runs only triad, etc.
- `--triad-only`/`--nstream-only` options removed (replaced by `--only Triad` and `--only Nstream`).
- `--only Triad` now runs `triad` in the exact same way as all other benchmarks, i.e., timing each individual iteration. Before, the outer loop was being timed.
- `--gigabytes` and similar option print the bandwidths in GB/s (or GiB/s, MB/s, MiB/s)

Bug fixes:
- Metrics for `Init` were incorrect; the timers from `Read` were incorrectly used for both `Init` and `Read`.

Future:
- After these changes, adding new benchmarks like `Scan` is pretty straightforward: bump benchmark count by 1, and add them to all places in the code that fail (runner, checker, and that's it..).

