### PR TITLE
Add support for 64-bit indices and large arrays

### DIFF
--- a/src/StreamModels.h
+++ b/src/StreamModels.h
@@ -36,7 +36,7 @@
 #endif
 
 template <typename T>
-std::unique_ptr<Stream<T>> make_stream(int array_size, int deviceIndex) {
+std::unique_ptr<Stream<T>> make_stream(intptr_t array_size, int deviceIndex) {
 #if defined(CUDA)
   // Use the CUDA implementation
   return std::make_unique<CUDAStream<T>>(array_size, deviceIndex);

--- a/src/acc/ACCStream.cpp
+++ b/src/acc/ACCStream.cpp
@@ -8,12 +8,11 @@
 #include "ACCStream.h"
 
 template <class T>
-ACCStream<T>::ACCStream(const int ARRAY_SIZE, int device)
+ACCStream<T>::ACCStream(const intptr_t ARRAY_SIZE, int device)
+  : array_size{ARRAY_SIZE}
 {
   acc_device_t device_type = acc_get_device_type();
   acc_set_device_num(device, device_type);
-
-  array_size = ARRAY_SIZE;
 
   // Set up data region on device
   this->a = new T[array_size];
@@ -32,7 +31,7 @@ template <class T>
 ACCStream<T>::~ACCStream()
 {
   // End data region on device
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
 
   T * restrict a = this->a;
   T * restrict b = this->b;
@@ -49,12 +48,12 @@ ACCStream<T>::~ACCStream()
 template <class T>
 void ACCStream<T>::init_arrays(T initA, T initB, T initC)
 {
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T * restrict a = this->a;
   T * restrict b = this->b;
   T * restrict c = this->c;
   #pragma acc parallel loop present(a[0:array_size], b[0:array_size], c[0:array_size]) wait
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] = initA;
     b[i] = initB;
@@ -70,16 +69,23 @@ void ACCStream<T>::read_arrays(std::vector<T>& h_a, std::vector<T>& h_b, std::ve
   T *c = this->c;
   #pragma acc update host(a[0:array_size], b[0:array_size], c[0:array_size])
   {}
+
+  for (intptr_t i = 0; i < array_size; i++)
+  {
+    h_a[i] = a[i];
+    h_b[i] = b[i];
+    h_c[i] = c[i];
+  }
 }
 
 template <class T>
 void ACCStream<T>::copy()
 {
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T * restrict a = this->a;
   T * restrict c = this->c;
   #pragma acc parallel loop present(a[0:array_size], c[0:array_size]) wait
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     c[i] = a[i];
   }
@@ -90,11 +96,11 @@ void ACCStream<T>::mul()
 {
   const T scalar = startScalar;
 
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T * restrict b = this->b;
   T * restrict c = this->c;
   #pragma acc parallel loop present(b[0:array_size], c[0:array_size]) wait
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     b[i] = scalar * c[i];
   }
@@ -103,12 +109,12 @@ void ACCStream<T>::mul()
 template <class T>
 void ACCStream<T>::add()
 {
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T * restrict a = this->a;
   T * restrict b = this->b;
   T * restrict c = this->c;
   #pragma acc parallel loop present(a[0:array_size], b[0:array_size], c[0:array_size]) wait
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     c[i] = a[i] + b[i];
   }
@@ -119,12 +125,12 @@ void ACCStream<T>::triad()
 {
   const T scalar = startScalar;
 
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T * restrict a = this->a;
   T * restrict b = this->b;
   T * restrict c = this->c;
   #pragma acc parallel loop present(a[0:array_size], b[0:array_size], c[0:array_size]) wait
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] = b[i] + scalar * c[i];
   }
@@ -135,12 +141,12 @@ void ACCStream<T>::nstream()
 {
   const T scalar = startScalar;
 
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T * restrict a = this->a;
   T * restrict b = this->b;
   T * restrict c = this->c;
   #pragma acc parallel loop present(a[0:array_size],  b[0:array_size], c[0:array_size]) wait
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] += b[i] + scalar * c[i];
   }
@@ -151,11 +157,11 @@ T ACCStream<T>::dot()
 {
   T sum{};
 
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T * restrict a = this->a;
   T * restrict b = this->b;
   #pragma acc parallel loop reduction(+:sum) present(a[0:array_size], b[0:array_size]) wait
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     sum += a[i] * b[i];
   }

--- a/src/acc/ACCStream.h
+++ b/src/acc/ACCStream.h
@@ -19,16 +19,15 @@
 template <class T>
 class ACCStream : public Stream<T>
 {
-
-	struct A{
-		T *a;
-		T *b;
-		T *c;
-	};
+  struct A{
+    T *a;
+    T *b;
+    T *c;
+  };
 
   protected:
     // Size of arrays
-    int array_size;
+    intptr_t array_size;
     A aa;
     // Device side pointers
     T *a;
@@ -36,7 +35,7 @@ class ACCStream : public Stream<T>
     T *c;
 
   public:
-    ACCStream(const int, int);
+    ACCStream(const intptr_t, int);
     ~ACCStream();
 
     virtual void copy() override;
@@ -48,7 +47,4 @@ class ACCStream : public Stream<T>
 
     virtual void init_arrays(T initA, T initB, T initC) override;
     virtual void read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector<T>& c) override;
-
-
-
 };

--- a/src/cuda/CUDAStream.cu
+++ b/src/cuda/CUDAStream.cu
@@ -20,7 +20,7 @@ __host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + 
 cudaStream_t stream;
 
 template <class T>
-CUDAStream<T>::CUDAStream(const int array_size, const int device_index)
+CUDAStream<T>::CUDAStream(const intptr_t array_size, const int device_index)
   : array_size(array_size)
 {
   // Set device
@@ -96,9 +96,9 @@ CUDAStream<T>::~CUDAStream()
 }
 
 template <typename T>
-__global__ void init_kernel(T * a, T * b, T * c, T initA, T initB, T initC, int array_size)
+__global__ void init_kernel(T * a, T * b, T * c, T initA, T initB, T initC, size_t array_size)
 {  
-  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     a[i] = initA;
     b[i] = initB;
     c[i] = initC;
@@ -120,7 +120,7 @@ void CUDAStream<T>::read_arrays(std::vector<T>& a, std::vector<T>& b, std::vecto
   // Copy device memory to host
 #if defined(PAGEFAULT) || defined(MANAGED)
   CU(cudaStreamSynchronize(stream));
-  for (int i = 0; i < array_size; ++i)
+  for (intptr_t i = 0; i < array_size; ++i)
   {
     a[i] = d_a[i];
     b[i] = d_b[i];
@@ -134,9 +134,9 @@ void CUDAStream<T>::read_arrays(std::vector<T>& a, std::vector<T>& b, std::vecto
 }
 
 template <typename T>
-__global__ void copy_kernel(const T * a, T * c, int array_size)
+__global__ void copy_kernel(const T * a, T * c, size_t array_size)
 {
-  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     c[i] = a[i];
   }
 }
@@ -151,10 +151,10 @@ void CUDAStream<T>::copy()
 }
 
 template <typename T>
-__global__ void mul_kernel(T * b, const T * c, int array_size)
+__global__ void mul_kernel(T * b, const T * c, size_t array_size)
 {
   const T scalar = startScalar;
-  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     b[i] = scalar * c[i];
   }
 }
@@ -169,9 +169,9 @@ void CUDAStream<T>::mul()
 }
 
 template <typename T>
-__global__ void add_kernel(const T * a, const T * b, T * c, int array_size)
+__global__ void add_kernel(const T * a, const T * b, T * c, size_t array_size)
 {
-  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     c[i] = a[i] + b[i];
   }
 }
@@ -186,10 +186,10 @@ void CUDAStream<T>::add()
 }
 
 template <typename T>
-__global__ void triad_kernel(T * a, const T * b, const T * c, int array_size)
+__global__ void triad_kernel(T * a, const T * b, const T * c, size_t array_size)
 {
   const T scalar = startScalar;
-  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     a[i] = b[i] + scalar * c[i];
   }
 }
@@ -204,10 +204,10 @@ void CUDAStream<T>::triad()
 }
 
 template <typename T>
-__global__ void nstream_kernel(T * a, const T * b, const T * c, int array_size)
+__global__ void nstream_kernel(T * a, const T * b, const T * c, size_t array_size)
 {
   const T scalar = startScalar;
-  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     a[i] += b[i] + scalar * c[i];
   }
 }
@@ -222,12 +222,12 @@ void CUDAStream<T>::nstream()
 }
 
 template <class T>
-__global__ void dot_kernel(const T * a, const T * b, T* sums, int array_size)
+__global__ void dot_kernel(const T * a, const T * b, T* sums, size_t array_size)
 {
   __shared__ T smem[TBSIZE];
   T tmp = T(0.);
   const size_t tidx = threadIdx.x;
-  for (int i = tidx + (size_t)blockDim.x * blockIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = tidx + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     tmp += a[i] * b[i];
   }
   smem[tidx] = tmp;
@@ -249,7 +249,7 @@ T CUDAStream<T>::dot()
   CU(cudaStreamSynchronize(stream));
 
   T sum = 0.0;
-  for (int i = 0; i < dot_num_blocks; ++i) sum += sums[i];
+  for (intptr_t i = 0; i < dot_num_blocks; ++i) sum += sums[i];
 
   return sum;
 }

--- a/src/cuda/CUDAStream.h
+++ b/src/cuda/CUDAStream.h
@@ -22,7 +22,7 @@ class CUDAStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    int array_size;
+    intptr_t array_size;
 
     // Host array for partial sums for dot kernel
     T *sums;
@@ -33,10 +33,10 @@ class CUDAStream : public Stream<T>
     T *d_c;
 
     // Number of blocks for dot kernel
-    int dot_num_blocks;
+    intptr_t dot_num_blocks;
 
   public:
-    CUDAStream(const int, const int);
+    CUDAStream(const intptr_t, const int);
     ~CUDAStream();
 
     virtual void copy() override;

--- a/src/hip/HIPStream.cpp
+++ b/src/hip/HIPStream.cpp
@@ -25,7 +25,7 @@ void check_error(void)
 __host__ __device__ constexpr size_t ceil_div(size_t a, size_t b) { return (a + b - 1)/b; }
 
 template <class T>
-HIPStream<T>::HIPStream(const int ARRAY_SIZE, const int device_index)
+HIPStream<T>::HIPStream(const intptr_t ARRAY_SIZE, const int device_index)
 {
   // Set device
   int count;
@@ -107,9 +107,9 @@ HIPStream<T>::~HIPStream()
 
 
 template <typename T>
-__global__ void init_kernel(T * a, T * b, T * c, T initA, T initB, T initC, int array_size)
+__global__ void init_kernel(T * a, T * b, T * c, T initA, T initB, T initC, size_t array_size)
 {
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     a[i] = initA;
     b[i] = initB;
     c[i] = initC;
@@ -133,7 +133,7 @@ void HIPStream<T>::read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector
   // Copy device memory to host
 #if defined(PAGEFAULT) || defined(MANAGED)
     hipDeviceSynchronize();
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] = d_a[i];
     b[i] = d_b[i];
@@ -150,9 +150,9 @@ void HIPStream<T>::read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector
 }
 
 template <typename T>
-__global__ void copy_kernel(const T * a, T * c, int array_size)
+__global__ void copy_kernel(const T * a, T * c, size_t array_size)
 {
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     c[i] = a[i];
   }
 }
@@ -168,10 +168,10 @@ void HIPStream<T>::copy()
 }
 
 template <typename T>
-__global__ void mul_kernel(T * b, const T * c, int array_size)
+__global__ void mul_kernel(T * b, const T * c, size_t array_size)
 {
   const T scalar = startScalar;
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     b[i] = scalar * c[i];
   }
 }
@@ -187,10 +187,9 @@ void HIPStream<T>::mul()
 }
 
 template <typename T>
-__global__ void add_kernel(const T * a, const T * b, T * c, int array_size)
+__global__ void add_kernel(const T * a, const T * b, T * c, size_t array_size)
 {
-  const size_t i = threadIdx.x + blockIdx.x * blockDim.x;
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     c[i] = a[i] + b[i];
   }
 }
@@ -206,10 +205,10 @@ void HIPStream<T>::add()
 }
 
 template <typename T>
-__global__ void triad_kernel(T * a, const T * b, const T * c, int array_size)
+__global__ void triad_kernel(T * a, const T * b, const T * c, size_t array_size)
 {
   const T scalar = startScalar;
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     a[i] = b[i] + scalar * c[i];
   }
 }
@@ -225,10 +224,10 @@ void HIPStream<T>::triad()
 }
 
 template <typename T>
-__global__ void nstream_kernel(T * a, const T * b, const T * c, int array_size)
+__global__ void nstream_kernel(T * a, const T * b, const T * c, size_t array_size)
 {
   const T scalar = startScalar;
-  for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < array_size; i += gridDim.x * blockDim.x) {
+  for (size_t i = (size_t)threadIdx.x + (size_t)blockDim.x * blockIdx.x; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
     a[i] += b[i] + scalar * c[i];
   }
 }
@@ -244,7 +243,7 @@ void HIPStream<T>::nstream()
 }
 
 template <typename T>
-__global__ void dot_kernel(const T * a, const T * b, T * sum, int array_size)
+__global__ void dot_kernel(const T * a, const T * b, T * sum, size_t array_size)
 {
   __shared__ T tb_sum[TBSIZE];
 
@@ -277,7 +276,7 @@ T HIPStream<T>::dot()
   check_error();
 
   T sum{};
-  for (int i = 0; i < dot_num_blocks; i++)
+  for (intptr_t i = 0; i < dot_num_blocks; i++)
     sum += sums[i];
 
   return sum;

--- a/src/hip/HIPStream.h
+++ b/src/hip/HIPStream.h
@@ -37,8 +37,8 @@ class HIPStream : public Stream<T>
 
   protected:
     // Size of arrays
-    int array_size;
-    int dot_num_blocks;
+    intptr_t array_size;
+    intptr_t dot_num_blocks;
 
     // Host array for partial sums for dot kernel
     T *sums;
@@ -51,7 +51,7 @@ class HIPStream : public Stream<T>
 
   public:
 
-    HIPStream(const int, const int);
+    HIPStream(const intptr_t, const int);
     ~HIPStream();
 
     virtual void copy() override;

--- a/src/kokkos/KokkosStream.cpp
+++ b/src/kokkos/KokkosStream.cpp
@@ -9,7 +9,7 @@
 
 template <class T>
 KokkosStream<T>::KokkosStream(
-        const int ARRAY_SIZE, const int device_index)
+        const intptr_t ARRAY_SIZE, const int device_index)
     : array_size(ARRAY_SIZE)
 {
   Kokkos::initialize(Kokkos::InitializationSettings().set_device_id(device_index));
@@ -53,7 +53,7 @@ void KokkosStream<T>::read_arrays(
   deep_copy(*hm_a, *d_a);
   deep_copy(*hm_b, *d_b);
   deep_copy(*hm_c, *d_c);
-  for(int ii = 0; ii < array_size; ++ii)
+  for(intptr_t ii = 0; ii < array_size; ++ii)
   {
     a[ii] = (*hm_a)(ii);
     b[ii] = (*hm_b)(ii);

--- a/src/kokkos/KokkosStream.hpp
+++ b/src/kokkos/KokkosStream.hpp
@@ -19,7 +19,7 @@ class KokkosStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    int array_size;
+    intptr_t array_size;
 
     // Device side pointers to arrays
      typename Kokkos::View<T*>* d_a;
@@ -31,7 +31,7 @@ class KokkosStream : public Stream<T>
 
   public:
 
-    KokkosStream(const int, const int);
+    KokkosStream(const intptr_t, const int);
     ~KokkosStream();
 
     virtual void copy() override;

--- a/src/legacy/HCStream.cpp
+++ b/src/legacy/HCStream.cpp
@@ -52,7 +52,7 @@ void listDevices(void)
 
 
 template <class T>
-HCStream<T>::HCStream(const int ARRAY_SIZE, const int device_index):
+HCStream<T>::HCStream(const intptr_t ARRAY_SIZE, const int device_index):
   array_size(ARRAY_SIZE),
   d_a(ARRAY_SIZE),
   d_b(ARRAY_SIZE),

--- a/src/legacy/HCStream.h
+++ b/src/legacy/HCStream.h
@@ -21,7 +21,7 @@ class HCStream : public Stream<T>
 {
 protected:
   // Size of arrays
-  int array_size;
+  intptr_t array_size;
   // Device side pointers to arrays
   hc::array<T,1> d_a;
   hc::array<T,1> d_b;
@@ -30,7 +30,7 @@ protected:
 
 public:
 
-  HCStream(const int, const int);
+  HCStream(const intptr_t, const int);
   ~HCStream();
 
   virtual void copy() override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2015-16 Tom Deakin, Simon McIntosh-Smith,
 // University of Bristol HPC
 //
@@ -22,7 +23,7 @@
 #include "Unit.h"
 
 // Default size of 2^25
-int ARRAY_SIZE = 33554432;
+intptr_t ARRAY_SIZE = 33554432;
 size_t num_times = 100;
 size_t deviceIndex = 0;
 bool use_float = false;
@@ -367,7 +368,7 @@ void check_solution(const size_t num_times,
   size_t failed = 0;
   T epsi = std::numeric_limits<T>::epsilon() * T(100000.0);
   auto check = [&](const char* name, T is, T should, T e, size_t i = size_t(-1)) {
-    if (e > epsi) {
+    if (e > epsi || std::isnan(e) || std::isnan(is)) {
       ++failed;
       if (failed > 10) return;
       std::cerr << "FAILED validation of " << name;

--- a/src/ocl/OCLStream.cpp
+++ b/src/ocl/OCLStream.cpp
@@ -75,7 +75,7 @@ std::string kernels{R"CLC(
     global const TYPE * restrict b,
     global TYPE * restrict sum,
     local TYPE * restrict wg_sum,
-    int array_size)
+    long array_size)
   {
     size_t i = get_global_id(0);
     const size_t local_i = get_local_id(0);
@@ -100,7 +100,8 @@ std::string kernels{R"CLC(
 
 
 template <class T>
-OCLStream<T>::OCLStream(const int ARRAY_SIZE, const int device_index)
+OCLStream<T>::OCLStream(const intptr_t ARRAY_SIZE, const int device_index)
+  : array_size{ARRAY_SIZE}
 {
   if (!cached)
     getDeviceList();
@@ -166,9 +167,7 @@ OCLStream<T>::OCLStream(const int ARRAY_SIZE, const int device_index)
   add_kernel = new cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer>(program, "add");
   triad_kernel = new cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer>(program, "triad");
   nstream_kernel = new cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer>(program, "nstream");
-  dot_kernel = new cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer, cl::LocalSpaceArg, cl_int>(program, "stream_dot");
-
-  array_size = ARRAY_SIZE;
+  dot_kernel = new cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer, cl::LocalSpaceArg, cl_long>(program, "stream_dot");
 
   // Check buffers fit on the device
   cl_ulong totalmem = device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>();

--- a/src/ocl/OCLStream.h
+++ b/src/ocl/OCLStream.h
@@ -26,7 +26,7 @@ class OCLStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    int array_size;
+    intptr_t array_size;
 
     // Host array for partial sums for dot kernel
     std::vector<T> sums;
@@ -48,7 +48,7 @@ class OCLStream : public Stream<T>
     cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer> *add_kernel;
     cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer> *triad_kernel;
     cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer> *nstream_kernel;
-    cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer, cl::LocalSpaceArg, cl_int> *dot_kernel;
+    cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer, cl::LocalSpaceArg, cl_long> *dot_kernel;
 
     // NDRange configuration for the dot kernel
     size_t dot_num_groups;
@@ -56,7 +56,7 @@ class OCLStream : public Stream<T>
 
   public:
 
-    OCLStream(const int, const int);
+    OCLStream(const intptr_t, const int);
     ~OCLStream();
 
     virtual void copy() override;

--- a/src/omp/OMPStream.cpp
+++ b/src/omp/OMPStream.cpp
@@ -13,7 +13,7 @@
 #endif
 
 template <class T>
-OMPStream<T>::OMPStream(const int ARRAY_SIZE, int device)
+OMPStream<T>::OMPStream(const intptr_t ARRAY_SIZE, int device)
 {
   array_size = ARRAY_SIZE;
 
@@ -39,7 +39,7 @@ OMPStream<T>::~OMPStream()
 {
 #ifdef OMP_TARGET_GPU
   // End data region on device
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   T *c = this->c;
@@ -54,7 +54,7 @@ OMPStream<T>::~OMPStream()
 template <class T>
 void OMPStream<T>::init_arrays(T initA, T initB, T initC)
 {
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
 #ifdef OMP_TARGET_GPU
   T *a = this->a;
   T *b = this->b;
@@ -63,7 +63,7 @@ void OMPStream<T>::init_arrays(T initA, T initB, T initC)
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] = initA;
     b[i] = initB;
@@ -89,7 +89,7 @@ void OMPStream<T>::read_arrays(std::vector<T>& h_a, std::vector<T>& h_b, std::ve
 #endif
 
   #pragma omp parallel for
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     h_a[i] = a[i];
     h_b[i] = b[i];
@@ -102,14 +102,14 @@ template <class T>
 void OMPStream<T>::copy()
 {
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *c = this->c;
   #pragma omp target teams distribute parallel for simd
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     c[i] = a[i];
   }
@@ -126,14 +126,14 @@ void OMPStream<T>::mul()
   const T scalar = startScalar;
 
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *b = this->b;
   T *c = this->c;
   #pragma omp target teams distribute parallel for simd
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     b[i] = scalar * c[i];
   }
@@ -148,7 +148,7 @@ template <class T>
 void OMPStream<T>::add()
 {
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   T *c = this->c;
@@ -156,7 +156,7 @@ void OMPStream<T>::add()
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     c[i] = a[i] + b[i];
   }
@@ -173,7 +173,7 @@ void OMPStream<T>::triad()
   const T scalar = startScalar;
 
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   T *c = this->c;
@@ -181,7 +181,7 @@ void OMPStream<T>::triad()
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] = b[i] + scalar * c[i];
   }
@@ -198,7 +198,7 @@ void OMPStream<T>::nstream()
   const T scalar = startScalar;
 
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   T *c = this->c;
@@ -206,7 +206,7 @@ void OMPStream<T>::nstream()
 #else
   #pragma omp parallel for
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     a[i] += b[i] + scalar * c[i];
   }
@@ -223,14 +223,14 @@ T OMPStream<T>::dot()
   T sum{};
 
 #ifdef OMP_TARGET_GPU
-  int array_size = this->array_size;
+  intptr_t array_size = this->array_size;
   T *a = this->a;
   T *b = this->b;
   #pragma omp target teams distribute parallel for simd map(tofrom: sum) reduction(+:sum)
 #else
   #pragma omp parallel for reduction(+:sum)
 #endif
-  for (int i = 0; i < array_size; i++)
+  for (intptr_t i = 0; i < array_size; i++)
   {
     sum += a[i] * b[i];
   }

--- a/src/omp/OMPStream.h
+++ b/src/omp/OMPStream.h
@@ -21,7 +21,7 @@ class OMPStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    int array_size;
+    intptr_t array_size;
 
     // Device side pointers
     T *a;
@@ -29,7 +29,7 @@ class OMPStream : public Stream<T>
     T *c;
 
   public:
-    OMPStream(const int, int);
+    OMPStream(const intptr_t, int);
     ~OMPStream();
 
     virtual void copy() override;
@@ -41,7 +41,4 @@ class OMPStream : public Stream<T>
 
     virtual void init_arrays(T initA, T initB, T initC) override;
     virtual void read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector<T>& c) override;
-
-
-
 };

--- a/src/raja/RAJAStream.cpp
+++ b/src/raja/RAJAStream.cpp
@@ -16,7 +16,7 @@ using RAJA::forall;
 #endif
 
 template <class T>
-RAJAStream<T>::RAJAStream(const int ARRAY_SIZE, const int device_index)
+RAJAStream<T>::RAJAStream(const intptr_t ARRAY_SIZE, const int device_index)
     : array_size(ARRAY_SIZE), range(0, ARRAY_SIZE)
 {
 
@@ -120,9 +120,14 @@ void RAJAStream<T>::triad()
 template <class T>
 void RAJAStream<T>::nstream()
 {
-  // TODO implement me!
-  std::cerr << "Not implemented yet!" << std::endl;
-  throw std::runtime_error("Not implemented yet!");
+  T* RAJA_RESTRICT a = d_a;
+  T* RAJA_RESTRICT b = d_b;
+  T* RAJA_RESTRICT c = d_c;
+  const T scalar = startScalar;
+  forall<policy>(range, [=] RAJA_DEVICE (RAJA::Index_type index)
+  {
+    a[index] += b[index] + scalar * c[index];;
+  });
 }
 
 template <class T>

--- a/src/raja/RAJAStream.hpp
+++ b/src/raja/RAJAStream.hpp
@@ -41,8 +41,8 @@ class RAJAStream : public Stream<T>
 {
   protected:
     // Size of arrays
-	const int array_size;
-	const RangeSegment range;
+    const intptr_t array_size;
+    const RangeSegment range;
 
     // Device side pointers to arrays
     T* d_a;
@@ -51,7 +51,7 @@ class RAJAStream : public Stream<T>
 
   public:
 
-    RAJAStream(const int, const int);
+    RAJAStream(const intptr_t, const int);
     ~RAJAStream();
 
     virtual void copy() override;

--- a/src/raja/model.cmake
+++ b/src/raja/model.cmake
@@ -99,7 +99,8 @@ macro(setup)
         message(STATUS "Building using packaged Raja at `${RAJA_IN_PACKAGE}`")
         find_package(RAJA REQUIRED)
         register_link_library(RAJA)
-    
+
+        set(CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS} "-forward-unknown-to-host-compiler -extended-lambda -arch=${CUDA_ARCH}" ${CUDA_EXTRA_FLAGS})
     else ()
         message(FATAL_ERROR "Neither `${RAJA_IN_TREE}` or `${RAJA_IN_PACKAGE}` exists")
     endif ()
@@ -111,7 +112,6 @@ macro(setup)
         set_source_files_properties(src/raja/RAJAStream.cpp PROPERTIES LANGUAGE CUDA)
         set_source_files_properties(src/main.cpp PROPERTIES LANGUAGE CUDA)
     endif ()
-
 
     register_append_compiler_and_arch_specific_cxx_flags(
             RAJA_FLAGS_CPU

--- a/src/std-data/STDDataStream.cpp
+++ b/src/std-data/STDDataStream.cpp
@@ -7,7 +7,7 @@
 #include "STDDataStream.h"
 
 template <class T>
-STDDataStream<T>::STDDataStream(const int ARRAY_SIZE, int device)
+STDDataStream<T>::STDDataStream(const intptr_t ARRAY_SIZE, int device)
   noexcept : array_size{ARRAY_SIZE},
   a(alloc_raw<T>(ARRAY_SIZE)), b(alloc_raw<T>(ARRAY_SIZE)), c(alloc_raw<T>(ARRAY_SIZE))
 {

--- a/src/std-data/STDDataStream.h
+++ b/src/std-data/STDDataStream.h
@@ -19,13 +19,13 @@ class STDDataStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    int array_size;
+    intptr_t array_size;
 
     // Device side pointers
     T *a, *b, *c;
 
   public:
-    STDDataStream(const int, int) noexcept;
+    STDDataStream(const intptr_t, int) noexcept;
     ~STDDataStream();
 
     virtual void copy() override;

--- a/src/std-data/model.cmake
+++ b/src/std-data/model.cmake
@@ -4,7 +4,7 @@ register_flag_optional(CMAKE_CXX_COMPILER
         "c++")
 
 register_flag_optional(NVHPC_OFFLOAD
-        "Enable offloading support (via the non-standard `-stdpar`) for the new NVHPC SDK.
+        "Enable offloading support (via the non-standard `-stdpar=gpu`) for the new NVHPC SDK.
          The values are Nvidia architectures in ccXY format will be passed in via `-gpu=` (e.g `cc70`)
 
          Possible values are:
@@ -38,7 +38,7 @@ register_flag_optional(USE_ONEDPL
 macro(setup)
     set(CMAKE_CXX_STANDARD 17)
     if (NVHPC_OFFLOAD)
-        set(NVHPC_FLAGS -stdpar -gpu=${NVHPC_OFFLOAD})
+        set(NVHPC_FLAGS -stdpar=gpu -gpu=${NVHPC_OFFLOAD})
         # propagate flags to linker so that it links with the gpu stuff as well
         register_append_cxx_flags(ANY ${NVHPC_FLAGS})
         register_append_link_flags(${NVHPC_FLAGS})

--- a/src/std-indices/STDIndicesStream.cpp
+++ b/src/std-indices/STDIndicesStream.cpp
@@ -11,7 +11,7 @@
 #endif
 
 template <class T>
-STDIndicesStream<T>::STDIndicesStream(const int ARRAY_SIZE, int device)
+STDIndicesStream<T>::STDIndicesStream(const intptr_t ARRAY_SIZE, int device)
 noexcept : array_size{ARRAY_SIZE}, range(0, array_size),
   a(alloc_raw<T>(ARRAY_SIZE)), b(alloc_raw<T>(ARRAY_SIZE)), c(alloc_raw<T>(ARRAY_SIZE))
 {
@@ -65,7 +65,7 @@ template <class T>
 void STDIndicesStream<T>::mul()
 {
   //  b[i] = scalar * c[i];
-  std::transform(exe_policy, range.begin(), range.end(), b, [c = this->c, scalar = startScalar](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), b, [c = this->c, scalar = startScalar](intptr_t i) {
     return scalar * c[i];
   });
 }
@@ -74,7 +74,7 @@ template <class T>
 void STDIndicesStream<T>::add()
 {
   //  c[i] = a[i] + b[i];
-  std::transform(exe_policy, range.begin(), range.end(), c, [a = this->a, b = this->b](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), c, [a = this->a, b = this->b](intptr_t i) {
     return a[i] + b[i];
   });
 }
@@ -83,7 +83,7 @@ template <class T>
 void STDIndicesStream<T>::triad()
 {
   //  a[i] = b[i] + scalar * c[i];
-  std::transform(exe_policy, range.begin(), range.end(), a, [b = this->b, c = this->c, scalar = startScalar](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), a, [b = this->b, c = this->c, scalar = startScalar](intptr_t i) {
     return b[i] + scalar * c[i];
   });
 }
@@ -95,7 +95,7 @@ void STDIndicesStream<T>::nstream()
   //  Need to do in two stages with C++11 STL.
   //  1: a[i] += b[i]
   //  2: a[i] += scalar * c[i];
-  std::transform(exe_policy, range.begin(), range.end(), a, [a = this->a, b = this->b, c = this->c, scalar = startScalar](int i) {
+  std::transform(exe_policy, range.begin(), range.end(), a, [a = this->a, b = this->b, c = this->c, scalar = startScalar](intptr_t i) {
     return a[i] + b[i] + scalar * c[i];
   });
 }

--- a/src/std-indices/STDIndicesStream.h
+++ b/src/std-indices/STDIndicesStream.h
@@ -71,16 +71,16 @@ class STDIndicesStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    int array_size;
+    intptr_t array_size;
 
     // induction range
-    ranged<int> range;
+    ranged<intptr_t> range;
 
     // Device side pointers
     T *a, *b, *c;
 
   public:
-    STDIndicesStream(const int, int) noexcept;
+    STDIndicesStream(const intptr_t, int) noexcept;
     ~STDIndicesStream();
 
     virtual void copy() override;

--- a/src/std-ranges/STDRangesStream.cpp
+++ b/src/std-ranges/STDRangesStream.cpp
@@ -12,7 +12,7 @@
 #endif
 
 template <class T>
-STDRangesStream<T>::STDRangesStream(const int ARRAY_SIZE, int device)
+STDRangesStream<T>::STDRangesStream(const intptr_t ARRAY_SIZE, int device)
 noexcept : array_size{ARRAY_SIZE},
   a(alloc_raw<T>(ARRAY_SIZE)), b(alloc_raw<T>(ARRAY_SIZE)), c(alloc_raw<T>(ARRAY_SIZE))
 {
@@ -44,8 +44,8 @@ void STDRangesStream<T>::init_arrays(T initA, T initB, T initC)
 {
   std::for_each_n(
     exe_policy,
-    std::views::iota(0).begin(), array_size, // loop range
-    [&] (int i) {
+    std::views::iota((intptr_t)0).begin(), array_size, // loop range
+    [=, this] (intptr_t i) {
       a[i] = initA;
       b[i] = initB;
       c[i] = initC;
@@ -67,8 +67,8 @@ void STDRangesStream<T>::copy()
 {
   std::for_each_n(
     exe_policy,
-    std::views::iota(0).begin(), array_size,
-    [&] (int i) {
+    std::views::iota((intptr_t)0).begin(), array_size,
+    [=, this] (intptr_t i) {
       c[i] = a[i];
     }
   );
@@ -81,8 +81,8 @@ void STDRangesStream<T>::mul()
 
   std::for_each_n(
     exe_policy,
-    std::views::iota(0).begin(), array_size,
-    [&] (int i) {
+    std::views::iota((intptr_t)0).begin(), array_size,
+    [=, this] (intptr_t i) {
       b[i] = scalar * c[i];
     }
   );
@@ -93,8 +93,8 @@ void STDRangesStream<T>::add()
 {
   std::for_each_n(
     exe_policy,
-    std::views::iota(0).begin(), array_size,
-    [&] (int i) {
+    std::views::iota((intptr_t)0).begin(), array_size,
+    [=, this] (intptr_t i) {
       c[i] = a[i] + b[i];
     }
   );
@@ -107,8 +107,8 @@ void STDRangesStream<T>::triad()
 
   std::for_each_n(
     exe_policy,
-    std::views::iota(0).begin(), array_size,
-    [&] (int i) {
+    std::views::iota((intptr_t)0).begin(), array_size,
+    [=, this] (intptr_t i) {
       a[i] = b[i] + scalar * c[i];
     }
   );
@@ -121,8 +121,8 @@ void STDRangesStream<T>::nstream()
 
   std::for_each_n(
     exe_policy,
-    std::views::iota(0).begin(), array_size,
-    [&] (int i) {
+    std::views::iota((intptr_t)0).begin(), array_size,
+    [=, this] (intptr_t i) {
       a[i] += b[i] + scalar * c[i];
     }
   );

--- a/src/std-ranges/STDRangesStream.hpp
+++ b/src/std-ranges/STDRangesStream.hpp
@@ -18,13 +18,13 @@ class STDRangesStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    int array_size;
+    intptr_t array_size;
 
     // Device side pointers
     T *a, *b, *c;
 
   public:
-    STDRangesStream(const int, int) noexcept;
+    STDRangesStream(const intptr_t, int) noexcept;
     ~STDRangesStream();
 
     virtual void copy() override;

--- a/src/std-ranges/model.cmake
+++ b/src/std-ranges/model.cmake
@@ -3,6 +3,22 @@ register_flag_optional(CMAKE_CXX_COMPILER
         "Any CXX compiler that is supported by CMake detection and supports C++20 Ranges"
         "c++")
 
+register_flag_optional(NVHPC_OFFLOAD
+        "Enable offloading support (via the non-standard `-stdpar=gpu`) for the new NVHPC SDK.
+         The values are Nvidia architectures in ccXY format will be passed in via `-gpu=` (e.g `cc70`)
+
+         Possible values are:
+           cc35  - Compile for compute capability 3.5
+           cc50  - Compile for compute capability 5.0
+           cc60  - Compile for compute capability 6.0
+           cc62  - Compile for compute capability 6.2
+           cc70  - Compile for compute capability 7.0
+           cc72  - Compile for compute capability 7.2
+           cc75  - Compile for compute capability 7.5
+           cc80  - Compile for compute capability 8.0
+           ccall - Compile for all supported compute capabilities"
+        "")
+
 register_flag_optional(USE_TBB
         "No-op if ONE_TBB_DIR is set. Link against an in-tree oneTBB via FetchContent_Declare, see top level CMakeLists.txt for details."
         "OFF")
@@ -29,6 +45,12 @@ macro(setup)
     unset(CMAKE_CXX_STANDARD) # drop any existing standard we have set by default
     # and append our own:
     register_append_cxx_flags(ANY -std=c++20)
+    if (NVHPC_OFFLOAD)
+        set(NVHPC_FLAGS -stdpar=gpu -gpu=${NVHPC_OFFLOAD})
+        # propagate flags to linker so that it links with the gpu stuff as well
+        register_append_cxx_flags(ANY ${NVHPC_FLAGS})
+        register_append_link_flags(${NVHPC_FLAGS})
+    endif ()
     if (USE_TBB)
         register_link_library(TBB::tbb)
     endif ()

--- a/src/sycl/SYCLStream.cpp
+++ b/src/sycl/SYCLStream.cpp
@@ -17,7 +17,7 @@ std::vector<device> devices;
 void getDeviceList(void);
 
 template <class T>
-SYCLStream<T>::SYCLStream(const int ARRAY_SIZE, const int device_index)
+SYCLStream<T>::SYCLStream(const intptr_t ARRAY_SIZE, const int device_index)
 {
   if (!cached)
     getDeviceList();

--- a/src/sycl/SYCLStream.h
+++ b/src/sycl/SYCLStream.h
@@ -54,7 +54,7 @@ class SYCLStream : public Stream<T>
 
   public:
 
-    SYCLStream(const int, const int);
+    SYCLStream(const intptr_t, const int);
     ~SYCLStream();
 
     virtual void copy() override;

--- a/src/sycl2020-acc/SYCLStream2020.cpp
+++ b/src/sycl2020-acc/SYCLStream2020.cpp
@@ -15,7 +15,7 @@ std::vector<sycl::device> devices;
 void getDeviceList(void);
 
 template <class T>
-SYCLStream<T>::SYCLStream(const size_t ARRAY_SIZE, const int device_index)
+SYCLStream<T>::SYCLStream(const intptr_t ARRAY_SIZE, const int device_index)
 : array_size {ARRAY_SIZE},
   d_a {ARRAY_SIZE},
   d_b {ARRAY_SIZE},

--- a/src/sycl2020-acc/SYCLStream2020.h
+++ b/src/sycl2020-acc/SYCLStream2020.h
@@ -35,7 +35,7 @@ class SYCLStream : public Stream<T>
 
   public:
 
-    SYCLStream(const size_t, const int);
+    SYCLStream(const intptr_t, const int);
     ~SYCLStream() = default;
 
     virtual void copy() override;

--- a/src/sycl2020-usm/SYCLStream2020.cpp
+++ b/src/sycl2020-usm/SYCLStream2020.cpp
@@ -15,7 +15,7 @@ std::vector<sycl::device> devices;
 void getDeviceList(void);
 
 template <class T>
-SYCLStream<T>::SYCLStream(const size_t ARRAY_SIZE, const int device_index)
+SYCLStream<T>::SYCLStream(const intptr_t ARRAY_SIZE, const int device_index)
 : array_size {ARRAY_SIZE}
 {
   if (!cached)

--- a/src/sycl2020-usm/SYCLStream2020.h
+++ b/src/sycl2020-usm/SYCLStream2020.h
@@ -35,7 +35,7 @@ class SYCLStream : public Stream<T>
 
   public:
 
-    SYCLStream(const size_t, const int);
+    SYCLStream(const intptr_t, const int);
     ~SYCLStream();
 
     virtual void copy() override;

--- a/src/tbb/TBBStream.cpp
+++ b/src/tbb/TBBStream.cpp
@@ -20,8 +20,8 @@
 #endif
 
 template <class T>
-TBBStream<T>::TBBStream(const int ARRAY_SIZE, int device)
- : partitioner(), range(0, ARRAY_SIZE),
+TBBStream<T>::TBBStream(const intptr_t ARRAY_SIZE, int device)
+  : partitioner(), range(0, (size_t)ARRAY_SIZE),
 #ifdef USE_VECTOR
    a(ARRAY_SIZE), b(ARRAY_SIZE), c(ARRAY_SIZE)
 #else

--- a/src/tbb/TBBStream.hpp
+++ b/src/tbb/TBBStream.hpp
@@ -47,10 +47,8 @@ class TBBStream : public Stream<T>
     T *a, *b, *c;
 #endif
 
-
-
   public:
-    TBBStream(const int, int);
+    TBBStream(const intptr_t, int);
     ~TBBStream() = default;
 
     virtual void copy() override;
@@ -62,6 +60,5 @@ class TBBStream : public Stream<T>
 
     virtual void init_arrays(T initA, T initB, T initC) override;
     virtual void read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector<T>& c) override;
-
 };
 

--- a/src/thrust/ThrustStream.cu
+++ b/src/thrust/ThrustStream.cu
@@ -19,8 +19,8 @@ static inline void synchronise()
 }
 
 template <class T>
-ThrustStream<T>::ThrustStream(const int ARRAY_SIZE, int device)
-    : array_size{ARRAY_SIZE}, a(array_size), b(array_size), c(array_size) {
+ThrustStream<T>::ThrustStream(const intptr_t array_size, int device)
+    : array_size{array_size}, a(array_size), b(array_size), c(array_size) {
   std::cout << "Using CUDA device: " << getDeviceName(device) << std::endl;
   std::cout << "Driver: " << getDeviceDriver(device) << std::endl;
   std::cout << "Thrust version: " << THRUST_VERSION << std::endl;

--- a/src/thrust/ThrustStream.h
+++ b/src/thrust/ThrustStream.h
@@ -23,7 +23,7 @@ class ThrustStream : public Stream<T>
 {
   protected:
     // Size of arrays
-    int array_size;
+    intptr_t array_size;
 
   #if defined(MANAGED)
     thrust::universtal_vector<T> a;
@@ -36,7 +36,7 @@ class ThrustStream : public Stream<T>
   #endif
 
   public:
-    ThrustStream(const int, int);
+    ThrustStream(const intptr_t, int);
     ~ThrustStream() = default;
 
     virtual void copy() override;


### PR DESCRIPTION
This PR adds support for 64-bit indices and large arrays. It is blocked on merging #186 .
Tested the following up to 141 GB of memory:
- cuda
- thrust
- std-data/indices/ranges
- omp
- raja
- tbb
- ocl

The following fail, and I need to minimize and report a bug; this PR does not regress them for small sizes:
- kokkos
- acc 

The following is not tested:
- hip: @tom91136 it would be good to test it and test whether `intptr_t` or `size_t` is better for the indices (or no difference).
- sycl