### PR TITLE
Add serial model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ endif ()
 include(cmake/register_models.cmake)
 
 # register out models <model_name> <preprocessor_def_name> <source files...>
+register_model(serial SERIAL SerialStream.cpp)
 register_model(omp OMP OMPStream.cpp)
 register_model(ocl OCL OCLStream.cpp)
 register_model(std-data STD_DATA STDDataStream.cpp)

--- a/src/StreamModels.h
+++ b/src/StreamModels.h
@@ -31,6 +31,8 @@
 #include "SYCLStream2020.h"
 #elif defined(OMP)
 #include "OMPStream.h"
+#elif defined(SERIAL)
+#include "SerialStream.h"
 #elif defined(FUTHARK)
 #include "FutharkStream.h"
 #endif
@@ -92,6 +94,10 @@ std::unique_ptr<Stream<T>> make_stream(intptr_t array_size, int deviceIndex) {
 #elif defined(OMP)
   // Use the OpenMP implementation
   return std::make_unique<OMPStream<T>>(array_size, deviceIndex);
+
+#elif defined(SERIAL)
+  // Use the Serial implementation
+  return std::make_unique<SerialStream<T>>(array_size, deviceIndex);
 
 #elif defined(FUTHARK)
   // Use the Futhark implementation

--- a/src/ci-test-compile.sh
+++ b/src/ci-test-compile.sh
@@ -138,6 +138,7 @@ build_gcc() {
   local name="gcc_build"
   local cxx="-DCMAKE_CXX_COMPILER=${GCC_CXX:?}"
 
+  run_build $name "${GCC_CXX:?}" serial "$cxx"
   run_build $name "${GCC_CXX:?}" omp "$cxx"
   if [ "$MODEL" = "all" ] || [ "$MODEL" = "OMP" ]; then
     # sanity check that it at least runs
@@ -219,6 +220,7 @@ build_gcc() {
 build_clang() {
   local name="clang_build"
   local cxx="-DCMAKE_CXX_COMPILER=${CLANG_CXX:?}"
+  run_build $name "${CLANG_CXX:?}" serial "$cxx"
   run_build $name "${CLANG_CXX:?}" omp "$cxx"
 
   if [ "${CLANG_OMP_OFFLOAD_AMD:-false}" != "false" ]; then
@@ -276,6 +278,7 @@ build_nvhpc() {
 }
 
 build_aocc() {
+  run_build aocc_build "${AOCC_CXX:?}" serial "-DCMAKE_CXX_COMPILER=${AOCC_CXX:?}"
   run_build aocc_build "${AOCC_CXX:?}" omp "-DCMAKE_CXX_COMPILER=${AOCC_CXX:?}"
 }
 
@@ -309,6 +312,7 @@ build_icpc() {
   set -u
   local name="intel_build"
   local cxx="-DCMAKE_CXX_COMPILER=${ICPC_CXX:?}"
+  run_build $name "${ICPC_CXX:?}" serial "$cxx"
   run_build $name "${ICPC_CXX:?}" omp "$cxx"
   run_build $name "${ICPC_CXX:?}" ocl "$cxx -DOpenCL_LIBRARY=${OCL_LIB:?}"
   if check_cmake_ver "3.20.0"; then

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #define VERSION_STRING "5.0"
 
 #include "Stream.h"
+
 #include "StreamModels.h"
 #include "Unit.h"
 

--- a/src/serial/SerialStream.cpp
+++ b/src/serial/SerialStream.cpp
@@ -1,0 +1,134 @@
+
+// Copyright (c) 2015-16 Tom Deakin, Simon McIntosh-Smith, Tom Lin
+// University of Bristol HPC
+//
+// For full license terms please see the LICENSE file distributed with this
+// source code
+
+#include <cstdlib>  // For aligned_alloc
+#include "SerialStream.h"
+
+#ifndef ALIGNMENT
+#define ALIGNMENT (2*1024*1024) // 2MB
+#endif
+
+template <class T>
+SerialStream<T>::SerialStream(const intptr_t ARRAY_SIZE, int device)
+{
+  array_size = ARRAY_SIZE;
+
+  // Allocate on the host
+  this->a = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
+  this->b = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
+  this->c = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
+}
+
+template <class T>
+SerialStream<T>::~SerialStream()
+{
+  free(a);
+  free(b);
+  free(c);
+}
+
+template <class T>
+void SerialStream<T>::init_arrays(T initA, T initB, T initC)
+{
+  intptr_t array_size = this->array_size;
+  for (intptr_t i = 0; i < array_size; i++)
+  {
+    a[i] = initA;
+    b[i] = initB;
+    c[i] = initC;
+  }
+}
+
+template <class T>
+void SerialStream<T>::read_arrays(std::vector<T>& h_a, std::vector<T>& h_b, std::vector<T>& h_c)
+{
+  for (intptr_t i = 0; i < array_size; i++)
+  {
+    h_a[i] = a[i];
+    h_b[i] = b[i];
+    h_c[i] = c[i];
+  }
+
+}
+
+template <class T>
+void SerialStream<T>::copy()
+{
+  for (intptr_t i = 0; i < array_size; i++)
+  {
+    c[i] = a[i];
+  }
+}
+
+template <class T>
+void SerialStream<T>::mul()
+{
+  const T scalar = startScalar;
+  for (intptr_t i = 0; i < array_size; i++)
+  {
+    b[i] = scalar * c[i];
+  }
+}
+
+template <class T>
+void SerialStream<T>::add()
+{
+  for (intptr_t i = 0; i < array_size; i++)
+  {
+    c[i] = a[i] + b[i];
+  }
+}
+
+template <class T>
+void SerialStream<T>::triad()
+{
+  const T scalar = startScalar;
+  for (intptr_t i = 0; i < array_size; i++)
+  {
+    a[i] = b[i] + scalar * c[i];
+  }
+}
+
+template <class T>
+void SerialStream<T>::nstream()
+{
+  const T scalar = startScalar;
+  for (intptr_t i = 0; i < array_size; i++)
+  {
+    a[i] += b[i] + scalar * c[i];
+  }
+}
+
+template <class T>
+T SerialStream<T>::dot()
+{
+  T sum{};
+  for (intptr_t i = 0; i < array_size; i++)
+  {
+    sum += a[i] * b[i];
+  }
+  return sum;
+}
+
+
+
+void listDevices(void)
+{
+  std::cout << "0: CPU" << std::endl;
+}
+
+std::string getDeviceName(const int)
+{
+  return std::string("Device name unavailable");
+}
+
+std::string getDeviceDriver(const int)
+{
+  return std::string("Device driver unavailable");
+}
+template class SerialStream<float>;
+template class SerialStream<double>;

--- a/src/serial/SerialStream.h
+++ b/src/serial/SerialStream.h
@@ -1,0 +1,43 @@
+
+// Copyright (c) 2015-16 Tom Deakin, Simon McIntosh-Smith, Tom Lin
+// University of Bristol HPC
+//
+// For full license terms please see the LICENSE file distributed with this
+// source code
+
+#pragma once
+
+#include <iostream>
+#include <stdexcept>
+
+#include "Stream.h"
+
+
+#define IMPLEMENTATION_STRING "Serial"
+
+template <class T>
+class SerialStream : public Stream<T>
+{
+  protected:
+    // Size of arrays
+    intptr_t array_size;
+
+    // Device side pointers
+    T *a;
+    T *b;
+    T *c;
+
+  public:
+    SerialStream(const intptr_t, int);
+    ~SerialStream();
+
+    virtual void copy() override;
+    virtual void add() override;
+    virtual void mul() override;
+    virtual void triad() override;
+    virtual void nstream() override;
+    virtual T dot() override;
+
+    virtual void init_arrays(T initA, T initB, T initC) override;
+    virtual void read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector<T>& c) override;
+};

--- a/src/serial/model.cmake
+++ b/src/serial/model.cmake
@@ -1,0 +1,4 @@
+macro(setup)
+    # Nothing to do
+endmacro()
+


### PR DESCRIPTION
Good thing to have when comparing with other parallel programming models, mostly for syntax.
This also makes us consistent with CloverLeaf, TeaLeaf, and miniBUDE.
Closes https://github.com/UoB-HPC/BabelStream/issues/190 .