### PR TITLE
Fix performance degradation of HIP dot

### DIFF
--- a/src/hip/HIPStream.cpp
+++ b/src/hip/HIPStream.cpp
@@ -56,7 +56,6 @@ HIPStream<T>::HIPStream(const intptr_t ARRAY_SIZE, const int device_index)
 
   size_t array_bytes = sizeof(T);
   array_bytes *= ARRAY_SIZE;
-  size_t total_bytes = array_bytes * 3;
 
   // Allocate the host array for partial sums for dot kernels using hipHostMalloc.
   // This creates an array on the host which is visible to the device. However, it requires
@@ -66,7 +65,7 @@ HIPStream<T>::HIPStream(const intptr_t ARRAY_SIZE, const int device_index)
   check_error();
 
   // Check buffers fit on the device
-  if (props.totalGlobalMem < std::size_t{3}*ARRAY_SIZE*sizeof(T))
+  if (props.totalGlobalMem < std::size_t{3}*array_bytes)
     throw std::runtime_error("Device does not have enough memory for all 3 buffers");
 
   // Create device buffers

--- a/src/hip/HIPStream.cpp
+++ b/src/hip/HIPStream.cpp
@@ -47,9 +47,12 @@ HIPStream<T>::HIPStream(const intptr_t ARRAY_SIZE, const int device_index)
     std::cout << "Memory: DEFAULT" << std::endl;
 #endif
 
+  hipDeviceProp_t props;
+  hipGetDeviceProperties(&props, device_index);
+  check_error();
+
   array_size = ARRAY_SIZE;
-  // Round dot_num_blocks up to next multiple of (TBSIZE * dot_elements_per_lane)
-  dot_num_blocks = (array_size + (TBSIZE * dot_elements_per_lane - 1)) / (TBSIZE * dot_elements_per_lane);
+  dot_num_blocks = props.multiProcessorCount * 4;
 
   size_t array_bytes = sizeof(T);
   array_bytes *= ARRAY_SIZE;
@@ -63,8 +66,6 @@ HIPStream<T>::HIPStream(const intptr_t ARRAY_SIZE, const int device_index)
   check_error();
 
   // Check buffers fit on the device
-  hipDeviceProp_t props;
-  hipGetDeviceProperties(&props, 0);
   if (props.totalGlobalMem < std::size_t{3}*ARRAY_SIZE*sizeof(T))
     throw std::runtime_error("Device does not have enough memory for all 3 buffers");
 

--- a/src/hip/HIPStream.h
+++ b/src/hip/HIPStream.h
@@ -14,27 +14,10 @@
 #include "Stream.h"
 
 #define IMPLEMENTATION_STRING "HIP"
-#define DOT_READ_DWORDS_PER_LANE 4
-
 
 template <class T>
 class HIPStream : public Stream<T>
 {
-  // Make sure that either:
-  //    DOT_READ_DWORDS_PER_LANE is less than sizeof(T), in which case we default to 1 element
-  //    or
-  //    DOT_READ_DWORDS_PER_LANE is divisible by sizeof(T)
-  static_assert((DOT_READ_DWORDS_PER_LANE * sizeof(unsigned int) < sizeof(T)) ||
-                (DOT_READ_DWORDS_PER_LANE * sizeof(unsigned int) % sizeof(T) == 0),
-                "DOT_READ_DWORDS_PER_LANE not divisible by sizeof(element_type)");
-
-  // Take into account the datatype size
-  // That is, for 4 DOT_READ_DWORDS_PER_LANE, this is 2 FP64 elements
-  // and 4 FP32 elements
-  static constexpr unsigned int dot_elements_per_lane{
-    (DOT_READ_DWORDS_PER_LANE * sizeof(unsigned int)) < sizeof(T) ? 1 : (
-     DOT_READ_DWORDS_PER_LANE * sizeof(unsigned int) / sizeof(T))};
-
   protected:
     // Size of arrays
     intptr_t array_size;


### PR DESCRIPTION
The workload of dot calculation is not consistent among the different implementations. The larger the arraysize, the longer it takes for the HIP version to complete.
 
```
# hip-stream -n 1500 -s $((1<<30)) | grep Dot
Dot         1376603.333 0.01248     0.01266     0.01251
# cuda-stream -n 1500 -s $((1<<30)) | grep Dot
Dot         1444860.830 0.01189     0.01199     0.01193
```
 
The HIP version currently uses arraysize to determine 'dot_num_blocks', which is used as kernel grid size and iteration count for reduction in the host code. The CUDA counterpart uses the number of SM (based on GPU specs) to determine 'dot_num_blocks'. The result should be more reliable with the CUDA one because of higher occupancy and more reasonable overhead of reduction on the host.