### PR TITLE
Make DoConcurrentStream.F90 conforming

### DIFF
--- a/src/fortran/DoConcurrentStream.F90
+++ b/src/fortran/DoConcurrentStream.F90
@@ -130,7 +130,7 @@ module DoConcurrentStream
 #ifdef CRAY_THREAD_DOCONCURRENT
             do i=1,N
 #else
-            do concurrent (i=1:N) !shared(A,B)
+            do concurrent (i=1:N) reduce(+:s) !shared(A,B)
 #endif
                s = s + A(i) * B(i)
             end do

--- a/src/fortran/make.inc.flang
+++ b/src/fortran/make.inc.flang
@@ -1,9 +1,9 @@
-FC	:= flang-new
+FC	?= flang-new
 FCFLAGS	:= -O3
 
-DOCONCURRENT_FLAG   =
+DOCONCURRENT_FLAG   = -fdo-concurrent-parallel=device -fopenmp --offload-arch=${GPUARCH} -DUSE_OMP_GET_WTIME
 ARRAY_FLAG          =
-OPENMP_FLAG         = -fopenmp
+OPENMP_FLAG         = -fopenmp --offload-arch=${GPUARCH} -DUSE_OMP_GET_WTIME
 OPENACC_FLAG        =
 CUDA_FLAG           =
 SEQUENTIAL_FLAG     =

--- a/src/fortran/make.inc.flang
+++ b/src/fortran/make.inc.flang
@@ -1,7 +1,7 @@
 FC	?= flang-new
 FCFLAGS	:= -O3
 
-DOCONCURRENT_FLAG   = -fdo-concurrent-parallel=device -fopenmp --offload-arch=${GPUARCH} -DUSE_OMP_GET_WTIME
+DOCONCURRENT_FLAG   =
 ARRAY_FLAG          =
 OPENMP_FLAG         = -fopenmp --offload-arch=${GPUARCH} -DUSE_OMP_GET_WTIME
 OPENACC_FLAG        =


### PR DESCRIPTION
 Use Fortran 2023 reduce locality specifier in order to have correct implementation.

Also add flags for LLVM flang OpenMP offloading implementation.