### PR TITLE
Add missing <cstdint> and <cstddef> headers.

### DIFF
--- a/src/StreamModels.h
+++ b/src/StreamModels.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <memory>
 
 #if defined(CUDA)

--- a/src/acc/ACCStream.h
+++ b/src/acc/ACCStream.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 

--- a/src/cuda/CUDAStream.h
+++ b/src/cuda/CUDAStream.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include <sstream>

--- a/src/hip/HIPStream.h
+++ b/src/hip/HIPStream.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include <sstream>

--- a/src/kokkos/KokkosStream.hpp
+++ b/src/kokkos/KokkosStream.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 

--- a/src/legacy/HCStream.h
+++ b/src/legacy/HCStream.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include <sstream>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -391,13 +391,21 @@ void check_solution(const size_t num_times,
   // Calculate the L^infty-norm relative error
   for (size_t i = 0; i < a.size(); ++i) {
     T vA = a[i], vB = b[i], vC = c[i];
-    T eA = std::fabs(vA - goldA) / std::fabs(goldA);
-    T eB = std::fabs(vB - goldB) / std::fabs(goldB);
-    T eC = std::fabs(vC - goldC) / std::fabs(goldC);
 
-    check("a", a[i], goldA, eA, i);
-    check("b", b[i], goldB, eB, i);
-    check("c", c[i], goldC, eC, i);
+    if (!(vA == T(0) && goldA == T(0))) {
+      T eA = std::fabs(vA - goldA) / std::fabs(goldA);
+      check("a", a[i], goldA, eA, i);
+    }
+
+    if (!(vB == T(0) && goldB == T(0))) {
+      T eB = std::fabs(vB - goldB) / std::fabs(goldB);
+      check("b", b[i], goldB, eB, i);
+    }
+
+    if (!(vC == T(0) && goldC == T(0))) {
+      T eC = std::fabs(vC - goldC) / std::fabs(goldC);
+      check("c", c[i], goldC, eC, i);
+    }
   }
 
   if (failed > 0 && !silence_errors)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
@@ -28,7 +29,7 @@ size_t num_times = 100;
 size_t deviceIndex = 0;
 bool use_float = false;
 bool output_as_csv = false;
-// Default unit of memory is MegaBytes (as per STREAM) 
+// Default unit of memory is MegaBytes (as per STREAM)
 Unit unit{Unit::Kind::MegaByte};
 bool silence_errors = false;
 std::string csv_separator = ",";

--- a/src/ocl/OCLStream.h
+++ b/src/ocl/OCLStream.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>

--- a/src/omp/OMPStream.h
+++ b/src/omp/OMPStream.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 

--- a/src/raja/RAJAStream.hpp
+++ b/src/raja/RAJAStream.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include "RAJA/RAJA.hpp"

--- a/src/std-data/STDDataStream.h
+++ b/src/std-data/STDDataStream.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "dpl_shim.h"
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include "Stream.h"

--- a/src/std-indices/STDIndicesStream.h
+++ b/src/std-indices/STDIndicesStream.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "dpl_shim.h"
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include "Stream.h"

--- a/src/std-ranges/STDRangesStream.hpp
+++ b/src/std-ranges/STDRangesStream.hpp
@@ -7,6 +7,7 @@
 #pragma once
 #include "dpl_shim.h"
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include "Stream.h"

--- a/src/sycl/SYCLStream.h
+++ b/src/sycl/SYCLStream.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <sstream>
 
 #include "Stream.h"

--- a/src/sycl2020-acc/SYCLStream2020.h
+++ b/src/sycl2020-acc/SYCLStream2020.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <sstream>
 #include <memory>
 

--- a/src/sycl2020-usm/SYCLStream2020.h
+++ b/src/sycl2020-usm/SYCLStream2020.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <sstream>
 #include <memory>
 

--- a/src/tbb/TBBStream.hpp
+++ b/src/tbb/TBBStream.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <iostream>
 #include <vector>
 #include "tbb/tbb.h"
@@ -36,7 +37,7 @@ template <class T>
 class TBBStream : public Stream<T>
 {
   protected:
-  
+
     tbb_partitioner partitioner;
     tbb::blocked_range<size_t> range;
     // Device side pointers

--- a/src/thrust/ThrustStream.h
+++ b/src/thrust/ThrustStream.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <vector>
 #if defined(MANAGED)


### PR DESCRIPTION
This PR fixes a bug introduced in #188 due to not adding the necessary `<cstdint>` headers when using `inptr_t`.

Additionally, as far as I understand the code, the current develop branch exhibits UB or, at best, implementation-defined behavior due to the new error checking introduced in #186. If I only enable, for example, the triad kernel, `goldC` is never written and, therefore, is equal to 0 (the value of `startC` in the `Stream.h` header). However, later, the error is calculate as 
```c++
T eC = std::fabs(vC - goldC) / std::fabs(goldC);
```
, which results in a division by zero and sets `eC` to NaN. In the `check` function, `eC` is tested against NaN and reports a failing check, although `vC` is **also** zero, in which case the result should be marked as correct. 
I added a (ugly) hotfix, but I'm currently unable to implement a better fix due to time constraints. 