### PR TITLE
Fix build regression by restoring Stream::init_arrays declaration

### DIFF
--- a/src/Stream.h
+++ b/src/Stream.h
@@ -41,6 +41,9 @@ class Stream
     virtual void nstream() = 0;
     virtual T dot() = 0;
 
+    // Reinitialize arrays to their starting values before a benchmark run.
+    virtual void init_arrays(T initA, T initB, T initC) = 0;
+
     // Set pointers to read from arrays
     virtual void get_arrays(T const*& a, T const*& b, T const*& c) = 0;
 };


### PR DESCRIPTION
Fixed #220 

## Fixed Result

```
$ cmake --build build-ocl -j
[ 33%] Building CXX object CMakeFiles/ocl-stream.dir/src/ocl/OCLStream.cpp.o
[ 66%] Building CXX object CMakeFiles/ocl-stream.dir/src/main.cpp.o
[100%] Linking CXX executable ocl-stream
[100%] Built target ocl-stream

$ ./build-ocl/ocl-stream 
BabelStream
Version: 5.0
Implementation: OpenCL
Running  Classic kernels 100 times in  Classic order
Number of elements: 33554432
Precision: double
Array size: 268.4 MB
Total size: 805.3 MB
Using OpenCL device Intel(R) Graphics [0x7d55]
Driver: 24.39.31294
Reduction kernel config: 512 groups of size 1024
Function    MB/s        Min (sec)   Max         Average     
Copy        54979.472   0.00976     0.01169     0.01030
Mul         55604.996   0.00966     0.01318     0.01022
Add         61187.565   0.01316     0.01681     0.01383
Triad       61646.053   0.01306     0.01923     0.01377
Dot         52044.908   0.01032     0.01384     0.01117
```
## What This PR Fixes
By Observing version from v5.0 -> v6.0-rc,

While still `main.cpp` requested init_array definition, but declaration of `init_array` was removed from `src/Stream.h`, so I restored it.

If it was intended, please feel free to close this PR. 

I'm totally fine with that.
