### PR TITLE
Improved CUDA performance through pipelined reads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endmacro()
 set(EXE_NAME babelstream)
 
 # for chrono, make_unique, and some basic CXX features, models can overwrite this if required
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 if (NOT CMAKE_BUILD_TYPE)
     message("No CMAKE_BUILD_TYPE specified, defaulting to 'Release'")

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -41,6 +41,9 @@ class Stream
     virtual void nstream() = 0;
     virtual T dot() = 0;
 
+    // Initialize arrays with the given values
+    virtual void init_arrays(T initA, T initB, T initC) = 0;
+
     // Set pointers to read from arrays
     virtual void get_arrays(T const*& a, T const*& b, T const*& c) = 0;
 };

--- a/src/cuda/CUDAStream.cu
+++ b/src/cuda/CUDAStream.cu
@@ -11,6 +11,15 @@
 #define UNROLL_FACTOR 4
 #endif
 
+#include <cuda/barrier>
+#include <cuda/ptx>
+
+#include <cub/cub.cuh>
+
+using barrier = cuda::barrier<cuda::thread_scope_block>;
+namespace ptx = cuda::ptx;
+
+
 [[noreturn]] inline void cuda_error(char const* file, int line, char const* expr, cudaError_t e) {
   std::fprintf(stderr, "CUDA Error at %s:%d: %s (%d)\n  %s\n", file, line, cudaGetErrorString(e), e, expr);
   exit(e);
@@ -234,76 +243,276 @@ void CUDAStream<T>::get_arrays(T const*& a, T const*& b, T const*& c)
 #endif
 }
 
+static constexpr int unroll = 4;
+static constexpr size_t buf_len = 1024;
+
+// Upper bound on the bulk-copy pipeline depth. Bounds the per-block shared-memory
+// mbarrier array, so it must be a compile-time constant.
+static constexpr int max_stages = 4;
+
+
+__device__ inline bool is_elected()
+{
+  unsigned int tid = threadIdx.x;
+  unsigned int warp_id = tid / 32;
+  unsigned int uniform_warp_id = __shfl_sync(0xFFFFFFFF, warp_id, 0); // Broadcast from lane 0.
+  return (uniform_warp_id == 0 && ptx::elect_sync(0xFFFFFFFF)); // Elect a leader thread among warp 0.
+}
+
+template <typename T>
+__global__ void copy_kernel(const T * a, T * c, size_t array_size)
+{
+  const size_t tile_size = blockDim.x * unroll;
+  const size_t offset = blockIdx.x * tile_size + threadIdx.x;
+  T a_reg[unroll];
+
+  // First: Load from global memory to registers
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+    {
+      size_t idx = offset + i * blockDim.x;
+      if (idx < array_size)
+        a_reg[i] = a[idx];
+    }
+
+  // Second: Store
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+    {
+      size_t idx = offset + i * blockDim.x;
+      if (idx < array_size)
+        c[idx] = a_reg[i];
+    }
+}
+
 template <class T>
 void CUDAStream<T>::copy()
 {
-  for_each(array_size, [a=d_a,c=d_c] __device__ (size_t i) {
-    c[i] = a[i];
-  });
+
+  size_t blocks = ceil_div(array_size/unroll, TBSIZE);
+  copy_kernel<<<blocks, TBSIZE, 0, stream>>>(d_a, d_c, array_size);
+  CU(cudaPeekAtLastError());
+  CU(cudaStreamSynchronize(stream));
+}
+
+template <typename T>
+__global__ void mul_kernel(T * b, const T * c, size_t array_size)
+{
+  const size_t tile_size = blockDim.x * unroll;
+  const size_t offset = blockIdx.x * tile_size + threadIdx.x;
+  T c_reg[unroll];
+
+  // First: Load from global memory to registers
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+    {
+      size_t idx = offset + i * blockDim.x;
+      if (idx < array_size)
+        c_reg[i] = c[idx];
+    }
+
+  // Second: Multiply and store
+  const T scalar = startScalar;
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+    {
+      size_t idx = offset + i * blockDim.x;
+      if (idx < array_size)
+        b[idx] = scalar * c_reg[i];
+    }
 }
 
 template <class T>
 void CUDAStream<T>::mul()
 {
-  for_each(array_size, [b=d_b,c=d_c] __device__ (size_t i) {
-    b[i] = startScalar * c[i];
-  });
+  size_t blocks = ceil_div(array_size/unroll, TBSIZE);
+  mul_kernel<<<blocks, TBSIZE, 0, stream>>>(d_b, d_c, array_size);
+  CU(cudaPeekAtLastError());
+  CU(cudaStreamSynchronize(stream));
+}
+
+template <typename T>
+__global__ void add_kernel(const T * a, const T * b, T * c, size_t array_size)
+{
+  const size_t tile_size = blockDim.x * unroll;
+  const size_t offset = blockIdx.x * tile_size + threadIdx.x;
+  T a_reg[unroll];
+  T b_reg[unroll];
+
+  // First: Load from global memory to registers
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+    {
+      size_t idx = offset + i * blockDim.x;
+      if (idx < array_size)
+        {
+          a_reg[i] = a[idx];
+          b_reg[i] = b[idx];
+        }
+    }
+
+  // Second: Add and store
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+    {
+      size_t idx = offset + i * blockDim.x;
+      if (idx < array_size)
+        c[idx] = a_reg[i] + b_reg[i];
+    }
 }
 
 template <class T>
 void CUDAStream<T>::add()
 {
-  for_each(array_size, [a=d_a,b=d_b,c=d_c] __device__ (size_t i) {
-    c[i] = a[i] + b[i];
-  });
+  size_t blocks = ceil_div(array_size/unroll, TBSIZE);
+  add_kernel<<<blocks, TBSIZE, 0, stream>>>(d_a, d_b, d_c, array_size);
+  CU(cudaPeekAtLastError());
+  CU(cudaStreamSynchronize(stream));
+}
+
+template <typename T>
+__global__ void triad_kernel(T * a, const T * b, const T * c, size_t array_size)
+{
+  const size_t tile_size = blockDim.x * unroll;
+  const size_t offset = blockIdx.x * tile_size + threadIdx.x;
+  T b_reg[unroll];
+  T c_reg[unroll];
+
+  // First: Load 2*unroll elements from global memory to registers
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+  {
+    if (offset + i * blockDim.x < array_size)
+      {
+        b_reg[i] = b[offset + i * blockDim.x];
+        c_reg[i] = c[offset + i * blockDim.x];
+      }
+  }
+
+  // Second: Add and store
+  const T scalar = startScalar;
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+  {
+    if (offset + i * blockDim.x < array_size)
+      a[offset + i * blockDim.x] = b_reg[i] + scalar * c_reg[i];
+  }
 }
 
 template <class T>
 void CUDAStream<T>::triad()
 {
-  for_each(array_size, [a=d_a,b=d_b,c=d_c] __device__ (size_t i) {
-    a[i] = b[i] + startScalar * c[i];
-  });
+  size_t blocks = ceil_div(array_size/unroll, TBSIZE);
+  triad_kernel<<<blocks, TBSIZE, 0, stream>>>(d_a, d_b, d_c, array_size);
+  CU(cudaPeekAtLastError());
+  CU(cudaStreamSynchronize(stream));
+}
+
+template <typename T>
+__global__ void nstream_kernel(T * a, const T * b, const T * c, size_t array_size)
+{
+  const size_t tile_size = blockDim.x * unroll;
+  const size_t offset = blockIdx.x * tile_size + threadIdx.x;
+  T a_reg[unroll];
+  T b_reg[unroll];
+  T c_reg[unroll];
+
+  // First: Load 3*unroll elements from global memory to registers
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+    {
+      size_t idx = offset + i * blockDim.x;
+      if (idx < array_size)
+        {
+          a_reg[i] = a[idx];
+          b_reg[i] = b[idx];
+          c_reg[i] = c[idx];
+        }
+    }
+
+  // Second: Compute and store
+  const T scalar = startScalar;
+#pragma unroll
+  for (int i = 0; i < unroll; i++)
+    {
+      size_t idx = offset + i * blockDim.x;
+      if (idx < array_size)
+        a[idx] = a_reg[i] + b_reg[i] + scalar * c_reg[i];
+    }
 }
 
 template <class T>
 void CUDAStream<T>::nstream()
 {
-  for_each(array_size, [a=d_a,b=d_b,c=d_c] __device__ (size_t i) {
-    a[i] += b[i] + startScalar * c[i];
-  });
+  size_t blocks = ceil_div(array_size/unroll, TBSIZE);
+  nstream_kernel<<<blocks, TBSIZE, 0, stream>>>(d_a, d_b, d_c, array_size);
+  CU(cudaPeekAtLastError());
+  CU(cudaStreamSynchronize(stream));
 }
+
+//#define TBSIZE_DOT 1024
 
 template <class T>
 __global__ void dot_kernel(const T * a, const T * b, T* sums, size_t array_size)
 {
-  __shared__ T smem[TBSIZE_DOT];
-  T tmp = T(0.);
-  const size_t tidx = threadIdx.x;
-  size_t i = tidx + (size_t)blockDim.x * blockIdx.x;
-  for (; i < array_size; i += (size_t)gridDim.x * blockDim.x) {
-    tmp += a[i] * b[i];
-  }
-  smem[tidx] = tmp;
+  typedef cub::BlockReduce<T, TBSIZE> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
 
-  for (int offset = blockDim.x / 2; offset > 0; offset /= 2) {
-    __syncthreads();
-    if (tidx < offset) smem[tidx] += smem[tidx+offset];
-  }
+  const size_t tile_size = blockDim.x * unroll;
+  const size_t offset = blockIdx.x * tile_size + threadIdx.x;
+
+  T a_reg[unroll];
+  T b_reg[unroll];
+  T partial_sum = {};
+
+  // Process with unrolling
+  for (size_t base = offset; base < array_size; base += tile_size * gridDim.x)
+    {
+      // First: Load from global memory to registers
+#pragma unroll
+      for (int u = 0; u < unroll; u++)
+        {
+          size_t idx = base + u * blockDim.x;
+          if (idx < array_size)
+            {
+              a_reg[u] = a[idx];
+              b_reg[u] = b[idx];
+            }
+          else
+            {
+              a_reg[u] = {};
+              b_reg[u] = {};
+            }
+        }
+
+      // Second: Compute dot products
+#pragma unroll
+      for (int u = 0; u < unroll; u++)
+        {
+          partial_sum += a_reg[u] * b_reg[u];
+        }
+    }
+
+  // CUB block-wide reduction
+  T block_sum = BlockReduce(temp_storage).Sum(partial_sum);
 
   // First thread writes to host memory directly from the device
-  if (tidx == 0) sums[blockIdx.x] = smem[tidx];
+  if (threadIdx.x == 0) sums[blockIdx.x] = block_sum;
+  // if (threadIdx.x == 0)
+    // atomicAdd(&sums[0], block_sum);
 }
+
 
 template <class T>
 T CUDAStream<T>::dot()
 {
-  dot_kernel<<<dot_num_blocks, TBSIZE_DOT, 0, stream>>>(d_a, d_b, sums, array_size);
+
+  dot_kernel<<<dot_num_blocks/unroll, TBSIZE, 0, stream>>>(d_a, d_b, sums, array_size);
   CU(cudaPeekAtLastError());
   CU(cudaStreamSynchronize(stream));
 
   T sum = 0.0;
-  for (intptr_t i = 0; i < dot_num_blocks; ++i) sum += sums[i];
+  for (intptr_t i = 0; i < dot_num_blocks/unroll; ++i) sum += sums[i];
 
   return sum;
 }

--- a/src/cuda/CUDAStream.cu
+++ b/src/cuda/CUDAStream.cu
@@ -455,7 +455,7 @@ void CUDAStream<T>::nstream()
 template <class T>
 __global__ void dot_kernel(const T * a, const T * b, T* sums, size_t array_size)
 {
-  typedef cub::BlockReduce<T, TBSIZE> BlockReduce;
+  typedef cub::BlockReduce<T, TBSIZE_DOT> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
 
   const size_t tile_size = blockDim.x * unroll;
@@ -507,7 +507,7 @@ template <class T>
 T CUDAStream<T>::dot()
 {
 
-  dot_kernel<<<dot_num_blocks/unroll, TBSIZE, 0, stream>>>(d_a, d_b, sums, array_size);
+  dot_kernel<<<dot_num_blocks/unroll, TBSIZE_DOT, 0, stream>>>(d_a, d_b, sums, array_size);
   CU(cudaPeekAtLastError());
   CU(cudaStreamSynchronize(stream));
 

--- a/src/cuda/model.cmake
+++ b/src/cuda/model.cmake
@@ -3,11 +3,12 @@ register_flag_optional(CMAKE_CXX_COMPILER
         "Any CXX compiler that is supported by CMake detection, this is used for host compilation"
         "c++")
 
+# "DEFAULT" define causes a compile error in newer cuda CCCL, so we change to BABEL_DEFAULT
 register_flag_optional(MEM "Device memory mode:
-        DEFAULT   - allocate host and device memory pointers.
+        BABEL_DEFAULT   - allocate host and device memory pointers.
         MANAGED   - use CUDA Managed Memory.
         PAGEFAULT - shared memory, only host pointers allocated."
-        "DEFAULT")
+        "BABEL_DEFAULT")
 
 register_flag_optional(STRIDE "Kernel stride: GRID_STRIDE or BLOCK_STRIDE" "GRID_STRIDE")
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,8 +30,8 @@
 #include <adiak.hpp>
 #endif
 
-// Default size of 2^25
-intptr_t array_size = 33554432;
+// Default size of 2^28
+intptr_t array_size = 268435456;
 size_t num_times = 100;
 size_t deviceIndex = 0;
 bool use_float = false;

--- a/src/thrust/ThrustStream.cu
+++ b/src/thrust/ThrustStream.cu
@@ -31,13 +31,8 @@ using vector =
 template <class T>
 struct ThrustStream<T>::Impl{
   vector<T> a, b, c;
+  thrust::host_vector<T> h_a, h_b, h_c;
 };
-
-template <class T>
-struct ThrustStream<T>::h_Impl{
-  thrust::host_vector<T> a, b, c;
-};
-
 
 static inline void synchronise()
 {
@@ -49,8 +44,7 @@ static inline void synchronise()
 
 template <class T>
 ThrustStream<T>::ThrustStream(BenchId selection, const intptr_t array_size, int device, T initA, T initB, T initC)
-    : array_size{array_size}, impl(new Impl{vector<T>(array_size), vector<T>(array_size), vector<T>(array_size)}),
-      h_impl(new h_Impl{}) {
+    : array_size{array_size}, impl(new Impl{vector<T>(array_size), vector<T>(array_size), vector<T>(array_size)}) {
   std::cout << "Using CUDA device: " << getDeviceName(device) << std::endl;
   std::cout << "Driver: " << getDeviceDriver(device) << std::endl;
   std::cout << "Thrust version: " << THRUST_VERSION << std::endl;
@@ -100,17 +94,17 @@ void ThrustStream<T>::get_arrays(T const*& a, T const*& b, T const*& c)
   c = thrust::raw_pointer_cast(impl->c.data());
 #else
   // No Unified memory: copy data to the host
-  h_impl->a.resize(array_size);
-  h_impl->b.resize(array_size);
-  h_impl->c.resize(array_size);
+  impl->h_a.resize(array_size);
+  impl->h_b.resize(array_size);
+  impl->h_c.resize(array_size);
 
-  thrust::copy(impl->a.begin(), impl->a.end(), h_impl->a.begin());
-  thrust::copy(impl->b.begin(), impl->b.end(), h_impl->b.begin());
-  thrust::copy(impl->c.begin(), impl->c.end(), h_impl->c.begin());
+  thrust::copy(impl->a.begin(), impl->a.end(), impl->h_a.begin());
+  thrust::copy(impl->b.begin(), impl->b.end(), impl->h_b.begin());
+  thrust::copy(impl->c.begin(), impl->c.end(), impl->h_c.begin());
 
-  a = h_impl->a.data();
-  b = h_impl->b.data();
-  c = h_impl->c.data();
+  a = impl->h_a.data();
+  b = impl->h_b.data();
+  c = impl->h_c.data();
 #endif
 }
 

--- a/src/thrust/ThrustStream.cu
+++ b/src/thrust/ThrustStream.cu
@@ -41,7 +41,7 @@ static inline void synchronise()
 }
 
 template <class T>
-ThrustStream<T>::ThrustStream(const intptr_t array_size, int device)
+ThrustStream<T>::ThrustStream(BenchId selection, const intptr_t array_size, int device, T initA, T initB, T initC)
     : array_size{array_size}, impl(new Impl{vector<T>(array_size), vector<T>(array_size), vector<T>(array_size)}) {
   std::cout << "Using CUDA device: " << getDeviceName(device) << std::endl;
   std::cout << "Driver: " << getDeviceDriver(device) << std::endl;
@@ -84,11 +84,11 @@ void ThrustStream<T>::init_arrays(T initA, T initB, T initC)
 }
 
 template <class T>
-void ThrustStream<T>::read_arrays(std::vector<T>& h_a, std::vector<T>& h_b, std::vector<T>& h_c)
+void ThrustStream<T>::get_arrays(T const*& a, T const*& b, T const*& c)
 {
-  thrust::copy(impl->a.begin(), impl->a.end(), h_a.begin());
-  thrust::copy(impl->b.begin(), impl->b.end(), h_b.begin());
-  thrust::copy(impl->c.begin(), impl->c.end(), h_c.begin());
+  a = thrust::raw_pointer_cast(impl->a.data());
+  b = thrust::raw_pointer_cast(impl->b.data());
+  c = thrust::raw_pointer_cast(impl->c.data());
 }
 
 template <class T>

--- a/src/thrust/ThrustStream.cu
+++ b/src/thrust/ThrustStream.cu
@@ -18,6 +18,7 @@
 #else
 #include <thrust/device_vector.h>
 #endif
+#include <thrust/host_vector.h>
 
 template <class T>
 using vector =
@@ -31,6 +32,12 @@ template <class T>
 struct ThrustStream<T>::Impl{
   vector<T> a, b, c;
 };
+
+template <class T>
+struct ThrustStream<T>::h_Impl{
+  thrust::host_vector<T> a, b, c;
+};
+
 
 static inline void synchronise()
 {
@@ -86,9 +93,24 @@ void ThrustStream<T>::init_arrays(T initA, T initB, T initC)
 template <class T>
 void ThrustStream<T>::get_arrays(T const*& a, T const*& b, T const*& c)
 {
+#if defined(PAGEFAULT) || defined(MANAGED)
   a = thrust::raw_pointer_cast(impl->a.data());
   b = thrust::raw_pointer_cast(impl->b.data());
   c = thrust::raw_pointer_cast(impl->c.data());
+#else
+  // No Unified memory: copy data to the host
+  h_impl->a.resize(array_size);
+  h_impl->b.resize(array_size);
+  h_impl->c.resize(array_size);
+
+  thrust::copy(impl->a.begin(), impl->a.end(), h_impl->a.begin());
+  thrust::copy(impl->b.begin(), impl->b.end(), h_impl->b.begin());
+  thrust::copy(impl->c.begin(), impl->c.end(), h_impl->c.begin());
+
+  a = h_impl->a.data();
+  b = h_impl->b.data();
+  c = h_impl->c.data();
+#endif
 }
 
 template <class T>

--- a/src/thrust/ThrustStream.cu
+++ b/src/thrust/ThrustStream.cu
@@ -49,7 +49,8 @@ static inline void synchronise()
 
 template <class T>
 ThrustStream<T>::ThrustStream(BenchId selection, const intptr_t array_size, int device, T initA, T initB, T initC)
-    : array_size{array_size}, impl(new Impl{vector<T>(array_size), vector<T>(array_size), vector<T>(array_size)}) {
+    : array_size{array_size}, impl(new Impl{vector<T>(array_size), vector<T>(array_size), vector<T>(array_size)}),
+      h_impl(new h_Impl{}) {
   std::cout << "Using CUDA device: " << getDeviceName(device) << std::endl;
   std::cout << "Driver: " << getDeviceDriver(device) << std::endl;
   std::cout << "Thrust version: " << THRUST_VERSION << std::endl;

--- a/src/thrust/ThrustStream.cu
+++ b/src/thrust/ThrustStream.cu
@@ -31,7 +31,10 @@ using vector =
 template <class T>
 struct ThrustStream<T>::Impl{
   vector<T> a, b, c;
+#if !(defined(PAGEFAULT) || defined(MANAGED))
+  // we need separate host allocations to hold the data for get_arrays()
   thrust::host_vector<T> h_a, h_b, h_c;
+#endif
 };
 
 static inline void synchronise()

--- a/src/thrust/ThrustStream.h
+++ b/src/thrust/ThrustStream.h
@@ -20,9 +20,7 @@ class ThrustStream : public Stream<T>
 {
   protected:
     struct Impl;
-    struct h_Impl;
     std::unique_ptr<Impl> impl; // avoid thrust vectors leaking into non-CUDA translation units
-    std::unique_ptr<h_Impl> h_impl; // If UVM is disabled, host arrays for verification purposes
     intptr_t array_size;
 
   public:

--- a/src/thrust/ThrustStream.h
+++ b/src/thrust/ThrustStream.h
@@ -24,7 +24,7 @@ class ThrustStream : public Stream<T>
     intptr_t array_size;
 
   public:
-    ThrustStream(intptr_t array_size, int device);
+    ThrustStream(BenchId selection, intptr_t array_size, int device, T initA, T initB, T initC);
     ~ThrustStream();
 
     void copy() override;

--- a/src/thrust/ThrustStream.h
+++ b/src/thrust/ThrustStream.h
@@ -20,7 +20,9 @@ class ThrustStream : public Stream<T>
 {
   protected:
     struct Impl;
+    struct h_Impl;
     std::unique_ptr<Impl> impl; // avoid thrust vectors leaking into non-CUDA translation units
+    std::unique_ptr<h_Impl> h_impl; // If UVM is disabled, host arrays for verification purposes
     intptr_t array_size;
 
   public:


### PR DESCRIPTION
This PR improves performance of all CUDA stream examples implemented through pipelined reads, particularly on Blackwell compute GPUs like GB200. For large enough arrays, we see performance of well over 7TB/s, which is much closer to the theoretical bandwidth available. I increased the default array size, to better saturate modern devices.

In this PR, I also fixed the compilation of the thrust version, which didn't get updated when the Stream interface changed.

I also made a small fix for compilation on CUDA 13.2, which can't have `-DDEFAULT` due to a compatibility issue with CCCL. I changed it to `-DBABEL_DEFAULT`.

Very open to feedback, thanks!