### PR TITLE
Quell missing override warning from HIPStream.h

### DIFF
--- a/src/hip/HIPStream.h
+++ b/src/hip/HIPStream.h
@@ -64,5 +64,5 @@ class HIPStream : public Stream<T>
     T dot() override;
 
     void get_arrays(T const*& a, T const*& b, T const*& c) override;    
-    void init_arrays(T initA, T initB, T initC);
+    void init_arrays(T initA, T initB, T initC) override;
 };


### PR DESCRIPTION
I get many of these warnings

> BabelStream/src/hip/HIPStream.h:67:10: warning: 'init_arrays' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]

when building the hip executable with this HIPCC version:

> $ hipcc --version
HIP version: 7.2.53211-97f5574fe2
AMD clang version 22.0.0git (https://github.com/RadeonOpenCompute/llvm-project roc-7.2.4 26084 f58b06dce1f9c15707c5f808fd002e18c2accf7e)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/rocm-7.2.4/lib/llvm/bin
Configuration file: /opt/rocm-7.2.4/lib/llvm/bin/clang++.cfg

The fix is just adding a probably forgotten override for this particular function