### PR TITLE
Centralize host allocation defaults across CPU backends

### DIFF
--- a/src/Alloc.h
+++ b/src/Alloc.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2015-16 Tom Deakin, Simon McIntosh-Smith,
+// University of Bristol HPC
+//
+// For full license terms please see the LICENSE file distributed with this
+// source code
+
+#pragma once
+
+#include <cstddef>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+// Host allocation defaults, shared by every model that allocates its arrays on
+// the host, so they all use the same alignment.
+
+#ifndef ALIGNMENT
+#define ALIGNMENT (2*1024*1024) // 2MB
+#endif
+
+template <class T>
+T *alloc_raw(size_t size)
+{
+  // aligned_alloc requires the size to be a multiple of the alignment, so round
+  // it up. glibc lets the unrounded size through, but other libcs return a null
+  // pointer, which used to show up as a crash for array sizes that are not a
+  // multiple of ALIGNMENT.
+  size_t bytes = sizeof(T) * size;
+  size_t rounded = ((bytes + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+
+  T *ptr = (T *)aligned_alloc(ALIGNMENT, rounded);
+  if (!ptr)
+    throw std::runtime_error("Failed to allocate " + std::to_string(rounded) + " bytes");
+
+  return ptr;
+}
+
+template <class T>
+void dealloc_raw(T *ptr) { free(ptr); }

--- a/src/dpl_shim.h
+++ b/src/dpl_shim.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#include <cstdlib>
 #include <cstddef>
-
-#ifndef ALIGNMENT
-#define ALIGNMENT (2*1024*1024) // 2MB
-#endif
 
 #ifdef USE_ONEDPL
 
@@ -58,11 +53,5 @@ static constexpr auto exe_policy = std::execution::par_unseq;
 #endif
 
 #ifdef USE_STD_PTR_ALLOC_DEALLOC
-
-template<typename T>
-T *alloc_raw(size_t size) { return (T *) aligned_alloc(ALIGNMENT, sizeof(T) * size); }
-
-template<typename T>
-void dealloc_raw(T *ptr) { free(ptr); }
-
+#include "Alloc.h"
 #endif

--- a/src/omp/OMPStream.cpp
+++ b/src/omp/OMPStream.cpp
@@ -5,15 +5,11 @@
 // For full license terms please see the LICENSE file distributed with this
 // source code
 
-#include <cstdlib>  // For aligned_alloc
 #include "OMPStream.h"
+#include "Alloc.h"
 
 #if defined(PAGEFAULT)
 #pragma omp requires unified_shared_memory
-#endif
-
-#ifndef ALIGNMENT
-#define ALIGNMENT (2*1024*1024) // 2MB
 #endif
 
 template <class T>
@@ -22,9 +18,9 @@ OMPStream<T>::OMPStream(BenchId bs, const intptr_t array_size, const int device,
   : array_size(array_size)
 {
   // Allocate on the host
-  this->a = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
-  this->b = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
-  this->c = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
+  this->a = alloc_raw<T>(array_size);
+  this->b = alloc_raw<T>(array_size);
+  this->c = alloc_raw<T>(array_size);
 
 #ifdef OMP_TARGET_GPU
   omp_set_default_device(device);
@@ -53,9 +49,9 @@ OMPStream<T>::~OMPStream()
   #pragma omp target exit data map(release: a[0:array_size], b[0:array_size], c[0:array_size])
   {}
 #endif
-  free(a);
-  free(b);
-  free(c);
+  dealloc_raw(a);
+  dealloc_raw(b);
+  dealloc_raw(c);
 }
 
 template <class T>

--- a/src/raja/RAJAStream.cpp
+++ b/src/raja/RAJAStream.cpp
@@ -5,15 +5,11 @@
 // For full license terms please see the LICENSE file distributed with this
 // source code
 
-#include <cstdlib>  // For aligned_alloc
 #include <stdexcept>
 #include "RAJAStream.hpp"
+#include "Alloc.h"
 
 using RAJA::forall;
-
-#ifndef ALIGNMENT
-#define ALIGNMENT (2*1024*1024) // 2MB
-#endif
 
 template <class T>
 RAJAStream<T>::RAJAStream(BenchId bs, const intptr_t array_size, const int device_index,
@@ -22,9 +18,9 @@ RAJAStream<T>::RAJAStream(BenchId bs, const intptr_t array_size, const int devic
 {
 
 #ifdef RAJA_TARGET_CPU
-  d_a = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
-  d_b = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
-  d_c = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
+  d_a = alloc_raw<T>(array_size);
+  d_b = alloc_raw<T>(array_size);
+  d_c = alloc_raw<T>(array_size);
 #else
   cudaMallocManaged((void**)&d_a, sizeof(T)*array_size, cudaMemAttachGlobal);
   cudaMallocManaged((void**)&d_b, sizeof(T)*array_size, cudaMemAttachGlobal);
@@ -39,9 +35,9 @@ template <class T>
 RAJAStream<T>::~RAJAStream()
 {
 #ifdef RAJA_TARGET_CPU
-  free(d_a);
-  free(d_b);
-  free(d_c);
+  dealloc_raw(d_a);
+  dealloc_raw(d_b);
+  dealloc_raw(d_c);
 #else
   cudaFree(d_a);
   cudaFree(d_b);

--- a/src/serial/SerialStream.cpp
+++ b/src/serial/SerialStream.cpp
@@ -5,12 +5,8 @@
 // For full license terms please see the LICENSE file distributed with this
 // source code
 
-#include <cstdlib>  // For aligned_alloc
 #include "SerialStream.h"
-
-#ifndef ALIGNMENT
-#define ALIGNMENT (2*1024*1024) // 2MB
-#endif
+#include "Alloc.h"
 
 template <class T>
 SerialStream<T>::SerialStream(BenchId bs, const intptr_t array_size, const int device_id,
@@ -18,9 +14,9 @@ SerialStream<T>::SerialStream(BenchId bs, const intptr_t array_size, const int d
   : array_size{array_size}
 {
   // Allocate on the host
-  this->a = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
-  this->b = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
-  this->c = (T*)aligned_alloc(ALIGNMENT, sizeof(T)*array_size);
+  this->a = alloc_raw<T>(array_size);
+  this->b = alloc_raw<T>(array_size);
+  this->c = alloc_raw<T>(array_size);
 
   init_arrays(initA, initB, initC);
 }
@@ -28,9 +24,9 @@ SerialStream<T>::SerialStream(BenchId bs, const intptr_t array_size, const int d
 template <class T>
 SerialStream<T>::~SerialStream()
 {
-  free(a);
-  free(b);
-  free(c);
+  dealloc_raw(a);
+  dealloc_raw(b);
+  dealloc_raw(c);
 }
 
 template <class T>

--- a/src/tbb/TBBStream.cpp
+++ b/src/tbb/TBBStream.cpp
@@ -5,11 +5,7 @@
 // source code
 
 #include "TBBStream.hpp"
-#include <cstdlib>
-
-#ifndef ALIGNMENT
-#define ALIGNMENT (2*1024*1024) // 2MB
-#endif
+#include "Alloc.h"
 
 #ifdef USE_VECTOR
 #define BEGIN(x) (x).begin()
@@ -27,9 +23,9 @@ TBBStream<T>::TBBStream(BenchId bs, const intptr_t array_size, const int device,
    a(array_size), b(array_size), c(array_size)
 #else
    array_size(array_size),
-   a((T *) aligned_alloc(ALIGNMENT, sizeof(T) * array_size)),
-   b((T *) aligned_alloc(ALIGNMENT, sizeof(T) * array_size)),
-   c((T *) aligned_alloc(ALIGNMENT, sizeof(T) * array_size))
+   a(alloc_raw<T>(array_size)),
+   b(alloc_raw<T>(array_size)),
+   c(alloc_raw<T>(array_size))
 #endif
 {
   if(device != 0){


### PR DESCRIPTION
## What this does

As mentioned by @gonzalobg in #201, allocations were scattered across `malloc`, `aligned_alloc(2MiB)`, and `new`. This PR consolidates the host allocation defaults into one place so all models pick up the same behavior.

* Added `src/Alloc.h` containing `ALIGNMENT`, `alloc_raw`, and `dealloc_raw`.
* `omp`, `raja`, `serial`, and `tbb` now use these shared helpers.
* The function names match what `dpl_shim.h` was already using, so the `std` model didn't require any code changes.
* `ALIGNMENT` is still wrapped in `#ifndef`, so overriding it via `-DALIGNMENT=...` works exactly like before.

## Bug fix: macOS `aligned_alloc` crash

`aligned_alloc` requires the requested size to be a multiple of the alignment. `glibc` is forgiving and lets unrounded sizes pass, but other libcs (like on macOS) return `NULL` instead. Since there was no null check, running `./serial-stream -s 1000` or `-s 1048577` on macOS caused a segfault (exit 139). It went unnoticed with the default size (`33554432`) because that happens to be a perfect multiple of 2MB.

* The size is now rounded up centrally in one place, fixing this for all models.
* A failed allocation now throws a `std::runtime_error` instead of returning null and crashing (this also matches how the HIP and CUDA models currently handle memory errors).

## Testing

* Environment: macOS 26.5, Apple clang, arm64.
* Built `serial` and `omp`.
* Ran 12 tests: 3 sizes (`1000`, `1048577`, `33554432`) × `double` and `float`. All passed with zero validation failures. (For context, the `1000` and `1048577` runs segfault on `main`).
* Performance: Triad default size was ~95,590 MB/s on `main`, and ~96,212 MB/s on this branch. No real difference, just normal noise.
* Untested locally: `raja`, `tbb`, and `std` (I don't have this toolchain set up on my Mac). The changes for `raja` and `tbb` are identical direct call swaps. (`std` doesn't build on my machine anyway since Apple clang lacks `<execution>`).

## Note on `sycl2020`

The `sycl2020` model has the exact same duplicated `ALIGNMENT` logic, but since PR #226 is actively rewriting that file, I intentionally left it out of this PR to avoid merge conflicts. I will do a quick follow-up PR for it once #226 is merged.
