### PR TITLE
[SYCL2020] Support device USM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,12 +184,6 @@ else ()
     message(STATUS "Selected model  :  ${MODEL}")
 endif ()
 
-if (MODEL STREQUAL "sycl2020")
-    message(FATAL_ERROR "
-    Model sycl2020 has been renamed to sycl2020-acc, and a new sycl2020-usm model is now available.
-    Please use sycl2020-acc for SYCL2020 style accessors and sycl2020-usm for USM")
-endif ()
-
 # load the $MODEL.cmake file and setup the correct IMPL_* based on $MODEL
 load_model(${MODEL})
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The source for each model's implementations are located in `./src/<model>`.
 
 Currently available models are:
 ```
-omp;ocl;std-data;std-indices;std-ranges;hip;cuda;kokkos;sycl;sycl2020-acc;sycl2020-usm;acc;raja;tbb;thrust;futhark
+omp;ocl;std-data;std-indices;std-ranges;hip;cuda;kokkos;sycl;sycl2020;acc;raja;tbb;thrust;futhark
 ```
 
 #### Overriding default flags

--- a/src/sycl/SYCLStream.h
+++ b/src/sycl/SYCLStream.h
@@ -66,7 +66,7 @@ class SYCLStream : public Stream<T>
     T    dot() override;
 
     void get_arrays(T const*& a, T const*& b, T const*& c) override;
-    void init_arrays(T initA, T initB, T initC);
+    void init_arrays(T initA, T initB, T initC) override;
 };
 
 // Populate the devices list

--- a/src/sycl2020/SYCLStream2020.cpp
+++ b/src/sycl2020/SYCLStream2020.cpp
@@ -28,6 +28,9 @@ SYCLStream<T>::SYCLStream(BenchId bs, const intptr_t array_size, const int devic
     throw std::runtime_error("Invalid device index");
 
   sycl::device dev = devices[device_index];
+  hostA.resize(array_size);
+  hostB.resize(array_size);
+  hostC.resize(array_size);
 
   // Print out device information
   std::cout << "Using SYCL device " << getDeviceName(device_index) << std::endl;
@@ -42,7 +45,7 @@ SYCLStream<T>::SYCLStream(BenchId bs, const intptr_t array_size, const int devic
     }
   }
 
-  queue = std::make_unique<sycl::queue>(dev, sycl::async_handler{[&](sycl::exception_list l)
+  auto async_handler = [&](sycl::exception_list l)
   {
     bool error = false;
     for(auto e: l)
@@ -61,7 +64,8 @@ SYCLStream<T>::SYCLStream(BenchId bs, const intptr_t array_size, const int devic
     {
       throw std::runtime_error("SYCL errors detected");
     }
-  }});
+  };
+  queue = std::make_unique<sycl::queue>(dev, async_handler, sycl::property::queue::in_order());
 
   // Allocate memory
 #if defined(PAGEFAULT)
@@ -70,22 +74,19 @@ SYCLStream<T>::SYCLStream(BenchId bs, const intptr_t array_size, const int devic
   c = (T*)aligned_alloc(ALIGNMENT, array_size * sizeof(T));
   sum = (T*)aligned_alloc(ALIGNMENT, ALIGNMENT);
 
-#elseif defined(SYCL2020ACC)
-  d_a = sycl::buffer<T>{array_size};
-  d_b = sycl::buffer<T>{array_size};
-  d_c = sycl::buffer<T>{array_size};
-  d_sum = sycl::buffer<T>{1};
-
-#elif SYCL2020USM
-  a = sycl::malloc_shared<T>(array_size, *queue);
-  b = sycl::malloc_shared<T>(array_size, *queue);
-  c = sycl::malloc_shared<T>(array_size, *queue);
-  sum = sycl::malloc_shared<T>(1, *queue);
-
 #else
-  #error unimplemented
+  use_shared_alloc =
+        queue->get_device().has(sycl::aspect::usm_shared_allocations);
+  a = use_shared_alloc ? sycl::malloc_shared<T>(array_size, *queue) :
+                         sycl::malloc_device<T>(array_size, *queue);
+  b = use_shared_alloc ? sycl::malloc_shared<T>(array_size, *queue) :
+                         sycl::malloc_device<T>(array_size, *queue);
+  c = use_shared_alloc ? sycl::malloc_shared<T>(array_size, *queue) :
+                         sycl::malloc_device<T>(array_size, *queue);
+  sum = use_shared_alloc ? sycl::malloc_shared<T>(1, *queue) :
+                           sycl::malloc_device<T>(1, *queue);
 #endif
-  
+
   // No longer need list of devices
   devices.clear();
   cached = true;
@@ -100,13 +101,11 @@ SYCLStream<T>::~SYCLStream() {
  free(b);
  free(c);
  free(sum);
-#ifdef SYCL2020USM
+#else
   sycl::free(a, *queue);
   sycl::free(b, *queue);
   sycl::free(c, *queue);
   sycl::free(sum, *queue);
-#else
-  #error unimplemented
 #endif
 }
 
@@ -115,10 +114,6 @@ void SYCLStream<T>::copy()
 {
   queue->submit([&](sycl::handler &cgh)
   {
-#ifdef SYCL2020ACC
-    sycl::accessor a {d_a, cgh, sycl::read_only};
-    sycl::accessor c {d_c, cgh, sycl::write_only};
-#endif    
     cgh.parallel_for(sycl::range<1>{array_size}, [c=c,a=a](sycl::id<1> idx)
     {
       c[idx] = a[idx];
@@ -133,10 +128,6 @@ void SYCLStream<T>::mul()
   const T scalar = startScalar;
   queue->submit([&](sycl::handler &cgh)
   {
-#ifdef SYCL2020ACC
-    sycl::accessor b {d_b, cgh, sycl::write_only};
-    sycl::accessor c {d_c, cgh, sycl::read_only};
-#endif    
     cgh.parallel_for(sycl::range<1>{array_size}, [=,b=b,c=c](sycl::id<1> idx)
     {
       b[idx] = scalar * c[idx];
@@ -150,11 +141,6 @@ void SYCLStream<T>::add()
 {
   queue->submit([&](sycl::handler &cgh)
   {
-#ifdef SYCL2020ACC
-    sycl::accessor a {d_a, cgh, sycl::read_only};
-    sycl::accessor b {d_b, cgh, sycl::read_only};
-    sycl::accessor c {d_c, cgh, sycl::write_only};
-#endif    
     cgh.parallel_for(sycl::range<1>{array_size}, [c=c,a=a,b=b](sycl::id<1> idx)
     {
       c[idx] = a[idx] + b[idx];
@@ -169,11 +155,6 @@ void SYCLStream<T>::triad()
   const T scalar = startScalar;
   queue->submit([&](sycl::handler &cgh)
   {
-#ifdef SYCL2020ACC    
-    sycl::accessor a {d_a, cgh, sycl::write_only};
-    sycl::accessor b {d_b, cgh, sycl::read_only};
-    sycl::accessor c {d_c, cgh, sycl::read_only};
-#endif    
     cgh.parallel_for(sycl::range<1>{array_size}, [=,a=a,b=b,c=c](sycl::id<1> idx)
     {
       a[idx] = b[idx] + scalar * c[idx];
@@ -188,11 +169,6 @@ void SYCLStream<T>::nstream()
   const T scalar = startScalar;
   queue->submit([&](sycl::handler &cgh)
   {
-#if SYCL2020ACC
-    sycl::accessor a {d_a, cgh};
-    sycl::accessor b {d_b, cgh, sycl::read_only};
-    sycl::accessor c {d_c, cgh, sycl::read_only};
-#endif    
     cgh.parallel_for(sycl::range<1>{array_size}, [=,a=a,b=b,c=c](sycl::id<1> idx)
     {
       a[idx] += b[idx] + scalar * c[idx];
@@ -206,10 +182,6 @@ T SYCLStream<T>::dot()
 {
   queue->submit([&](sycl::handler &cgh)
   {
-#if SYCL2020ACC    
-    sycl::accessor a {d_a, cgh, sycl::read_only};
-    sycl::accessor b {d_b, cgh, sycl::read_only};
-#endif
     cgh.parallel_for(sycl::range<1>{array_size},
       // Reduction object, to perform summation - initialises the result to zero
       // AdaptiveCpp doesn't sypport the initialize_to_identity property yet
@@ -223,8 +195,15 @@ T SYCLStream<T>::dot()
         sum += a[idx] * b[idx];
       });
   });
+  if (use_shared_alloc) {
+    queue->wait();
+    return *sum;
+  }
+
+  T hostSum;
+  queue->copy(sum, &hostSum, 1);
   queue->wait();
-  return *sum;
+  return hostSum;
 }
 
 template <class T>
@@ -240,11 +219,6 @@ void SYCLStream<T>::init_arrays(T initA, T initB, T initC)
 #else
   queue->submit([&](sycl::handler &cgh)
   {
-#if SYCL2020ACC    
-    sycl::accessor a {d_a, cgh, sycl::write_only, sycl::no_init};
-    sycl::accessor b {d_b, cgh, sycl::write_only, sycl::no_init};
-    sycl::accessor c {d_c, cgh, sycl::write_only, sycl::no_init};
-#endif
     cgh.parallel_for(sycl::range<1>{array_size}, [=,a=a,b=b,c=c](sycl::id<1> idx)
     {
       a[idx] = initA;
@@ -259,14 +233,20 @@ void SYCLStream<T>::init_arrays(T initA, T initB, T initC)
 template <class T>
 void SYCLStream<T>::get_arrays(T const*& h_a, T const*& h_b, T const*& h_c)
 {
-#if SYCL2020ACC
-  sycl::host_accessor a {d_a, sycl::read_only};
-  sycl::host_accessor b {d_b, sycl::read_only};
-  sycl::host_accessor c {d_c, sycl::read_only};
-#endif  
-  h_a = &a[0];
-  h_b = &b[0];
-  h_c = &c[0];
+  if (use_shared_alloc) {
+    h_a = &a[0];
+    h_b = &b[0];
+    h_c = &c[0];
+  } else {
+    queue->copy(a, hostA.data(), array_size);
+    queue->copy(b, hostB.data(), array_size);
+    queue->copy(c, hostC.data(), array_size);
+    queue->wait();
+
+    h_a = hostA.data();
+    h_b = hostB.data();
+    h_c = hostC.data();
+  }
 }
 
 void getDeviceList(void)

--- a/src/sycl2020/SYCLStream2020.h
+++ b/src/sycl2020/SYCLStream2020.h
@@ -14,15 +14,7 @@
 
 #include <sycl/sycl.hpp>
 
-#ifdef SYCL2020ACC
-#define SYCLIMPL "Accessors"
-#elif SYCL2020USM
-#define SYCLIMPL "USM"
-#else
-#error unimplemented
-#endif
-
-#define IMPLEMENTATION_STRING "SYCL2020 " SYCLIMPL
+#define IMPLEMENTATION_STRING "SYCL2020 "
 
 template <class T>
 class SYCLStream : public Stream<T>
@@ -30,6 +22,7 @@ class SYCLStream : public Stream<T>
   protected:
     // Size of arrays
     size_t array_size;
+    bool use_shared_alloc;
 
     // SYCL objects
     // Queue is a pointer because we allow device selection
@@ -37,7 +30,9 @@ class SYCLStream : public Stream<T>
 
     // Buffers
     T *a, *b, *c, *sum{};
-    sycl::buffer<T> d_a, d_b, d_c, d_sum;
+
+    // used to implement get_arrays for device USM
+    std::vector<T> hostA, hostB, hostC;
 
   public:
 
@@ -52,8 +47,8 @@ class SYCLStream : public Stream<T>
     void nstream() override;
     T    dot() override;
 
-    void get_arrays(T const*& a, T const*& b, T const*& c) override;    
-    void init_arrays(T initA, T initB, T initC);
+    void get_arrays(T const*& a, T const*& b, T const*& c) override;
+    void init_arrays(T initA, T initB, T initC) override;
 };
 
 // Populate the devices list

--- a/src/sycl2020/model.cmake
+++ b/src/sycl2020/model.cmake
@@ -24,15 +24,8 @@ register_flag_optional(MEM "Device memory mode:
         PAGEFAULT - shared memory, only host pointers allocated."
         "DEFAULT")
 
-register_flag_optional(SYCL_ACCESS
-  "Data access method:
-     - ACCESSOR
-     - USM"
-  "ACCESSOR")
-
 macro(setup)
     set(CMAKE_CXX_STANDARD 17)
-    register_definitions(${SYCL_ACCESS})
     if (${SYCL_COMPILER} STREQUAL "AdaptiveCpp")
         set(adaptivecpp_DIR ${SYCL_COMPILER_DIR}/lib/cmake/adaptivecpp)
 


### PR DESCRIPTION
Add device USM support to the SYCL2020 model for SYCL devices that don't support shared USM.

This patch also cleans up the build infrastructure for the SYCL2020 model which currently fails to build. In particular:

* Makes consistent in doc and cmake that `-DMODEL=sycl2020` should be passed rather than `sycl2020-usm` or `sycl2020-acc`.
* Removes buffer/accessors from model, as this code is broken in several ways that means it won't compile. For example, using default buffer constructor and not being passed to the reduction correctly. USM is the preferred memory model in SYCL2020 so I think only using it is fine as buffer/accessors are used in the other SYCL 1.2 model.